### PR TITLE
Closes #37: Add macro for setting thread-local context params for logs

### DIFF
--- a/src/ziggurat/util/logging.clj
+++ b/src/ziggurat/util/logging.clj
@@ -1,0 +1,9 @@
+(ns ziggurat.util.logging
+  (:import (org.apache.logging.log4j ThreadContext)))
+
+(defmacro with-context
+  [context-map & body]
+  `(try
+     (doseq [[k# v#] ~context-map] (ThreadContext/put (name k#) (str v#)))
+     ~@body
+     (finally (doseq [[k# _#] ~context-map] (ThreadContext/remove (name k#))))))

--- a/test/ziggurat/util/logging_test.clj
+++ b/test/ziggurat/util/logging_test.clj
@@ -1,0 +1,20 @@
+(ns ziggurat.util.logging-test
+  (:require [clojure.test :refer :all]
+            [ziggurat.util.logging :as zlog])
+  (:import (org.apache.logging.log4j ThreadContext)))
+
+(deftest with-context-test
+  (let [capture-context #(reset! % (into {} (ThreadContext/getImmutableContext)))]
+    (testing "sets thread local log context params within body"
+      (let [context-map (atom {})]
+        (zlog/with-context {:param-1 "string-value", :param-2 123}
+          (capture-context context-map))
+        (is (= "string-value" (get @context-map "param-1")))
+        (is (= "123" (get @context-map "param-2")))))
+
+    (testing "clears thread local log context params when exits"
+      (let [context-map (atom {})]
+        (zlog/with-context {:param-1 "string-value", :param-2 123}
+          (constantly nil))
+        (capture-context context-map)
+        (is (empty? @context-map))))))


### PR DESCRIPTION
This adds a macro for setting Thread local context params for logs. 