### PR TITLE
[Shan|~dp~] Actor stop fn should stop before the ziggurat state

### DIFF
--- a/src/ziggurat/init.clj
+++ b/src/ziggurat/init.clj
@@ -114,9 +114,9 @@
 (defn stop
   "Calls the Ziggurat's state stop fns and then actor-stop-fn."
   [actor-stop-fn modes]
+  (actor-stop-fn)
   (stop-common-states)
-  (execute-function modes :stop-fn)
-  (actor-stop-fn))
+  (execute-function modes :stop-fn))
 
 (defn- add-shutdown-hook [actor-stop-fn modes]
   (.addShutdownHook

--- a/test/ziggurat/init_test.clj
+++ b/test/ziggurat/init_test.clj
@@ -21,14 +21,14 @@
         (is (= 16 @result))))))
 
 (deftest stop-calls-actor-stop-fn-test
-  (testing "The actor stop fn stops after the ziggurat state"
+  (testing "The actor stop fn stops before the ziggurat state"
     (let [result (atom 1)]
       (with-redefs [streams/start-streams (constantly nil)
                     streams/stop-streams  (fn [_] (reset! result (* @result 2)))
                     config/config-file    "config.test.edn"]
         (init/start #() {} [] nil)
         (init/stop #(reset! result (+ @result 3)) nil)
-        (is (= 5 @result))))))
+        (is (= 8 @result))))))
 
 (deftest stop-calls-idempotentcy-test
   (testing "The stop function should be idempotent"
@@ -39,7 +39,7 @@
                     config/config-file    "config.test.edn"]
         (init/start #() {} [] nil)
         (init/stop #(reset! result (+ @result 3)) nil)
-        (is (= 5 @result))))))
+        (is (= 8 @result))))))
 
 (deftest start-calls-make-queues-test
   (testing "Start calls make queues"


### PR DESCRIPTION
This commit executed actor stop function first and then stops ziggurat stop function.