### PR TITLE
refactor the inclusion of the actor key/value in the tags

### DIFF
--- a/src/ziggurat/init.clj
+++ b/src/ziggurat/init.clj
@@ -4,20 +4,19 @@
             [mount.core :as mount :refer [defstate]]
             [schema.core :as s]
             [ziggurat.config :refer [ziggurat-config] :as config]
-            [ziggurat.metrics :as metrics]
             [ziggurat.messaging.connection :as messaging-connection]
             [ziggurat.messaging.consumer :as messaging-consumer]
             [ziggurat.messaging.producer :as messaging-producer]
+            [ziggurat.metrics :as metrics]
             [ziggurat.nrepl-server :as nrepl-server]
+            [ziggurat.producer :as producer :refer [kafka-producers]]
             [ziggurat.sentry :refer [sentry-reporter]]
             [ziggurat.server :as server]
-            [ziggurat.streams :as streams]
-            [ziggurat.producer :as producer :refer [kafka-producers]]))
+            [ziggurat.streams :as streams]))
 
 (defstate statsd-reporter
   :start (metrics/start-statsd-reporter (:datadog (ziggurat-config))
-                                        (:env (ziggurat-config))
-                                        (:app-name (ziggurat-config)))
+                                        (:env (ziggurat-config)))
   :stop (metrics/stop-statsd-reporter statsd-reporter))
 
 (defn- start*
@@ -154,7 +153,7 @@
     (s/validate StreamRoute stream-routes)))
 
 (defn validate-modes [modes]
-  (let [invalid-modes (filter #(not (contains? (set (keys valid-modes-fns)) %)) modes)
+  (let [invalid-modes       (filter #(not (contains? (set (keys valid-modes-fns)) %)) modes)
         invalid-modes-count (count invalid-modes)]
     (when (pos? invalid-modes-count)
       (throw (ex-info "Wrong modes arguement passed - " {:invalid-modes invalid-modes})))))

--- a/src/ziggurat/mapper.clj
+++ b/src/ziggurat/mapper.clj
@@ -20,7 +20,7 @@
           new-relic-transaction-name (str topic-entity-name ".handler-fn")
           default-namespace          "message-processing"
           metric-namespaces          [service-name topic-entity-name default-namespace]
-          additional-tags            {:topic_name topic-entity-name}
+          additional-tags            {:actor service-name :topic_name topic-entity-name}
           default-namespaces         [default-namespace]
           success-metric             "success"
           retry-metric               "retry"
@@ -59,7 +59,7 @@
           default-namespace  "message-processing"
           base-namespaces    [service-name topic-entity-name channel-name]
           metric-namespaces  (conj base-namespaces default-namespace)
-          additional-tags    {:topic_name topic-entity-name}
+          additional-tags    {:actor service-name :topic_name topic-entity-name}
           default-namespaces [default-namespace]
           metric-namespace   (str/join "." metric-namespaces)
           success-metric     "success"

--- a/src/ziggurat/streams.clj
+++ b/src/ziggurat/streams.clj
@@ -65,7 +65,7 @@
 (defn- log-and-report-metrics [topic-entity message]
   (let [service-name       (:app-name (ziggurat-config))
         topic-entity-name  (name topic-entity)
-        additional-tags    {:topic_name topic-entity-name}
+        additional-tags    {:actor service-name :topic_name topic-entity-name}
         default-namespace  "message"
         metric-namespaces  [service-name topic-entity-name default-namespace]
         default-namespaces [default-namespace]
@@ -95,7 +95,7 @@
 (defn- transform-values [topic-entity-name oldest-processed-message-in-s stream-builder]
   (let [service-name      (:app-name (ziggurat-config))
         metric-namespaces [service-name topic-entity-name "message-received-delay-histogram"]
-        additional-tags   {:topic_name topic-entity-name}]
+        additional-tags   {:actor service-name :topic_name topic-entity-name}]
     (.transform stream-builder (transformer-supplier metric-namespaces oldest-processed-message-in-s additional-tags) (into-array [(.name (store-supplier-builder))]))))
 
 (defn- protobuf->hash [message proto-class topic-entity-name]
@@ -111,9 +111,9 @@
       (select-keys loaded-proto proto-keys))
     (catch Throwable e
       (let [service-name      (:app-name (ziggurat-config))
-            additional-tags   {:topic_name topic-entity-name}
+            additional-tags   {:actor service-name :topic_name topic-entity-name}
             default-namespace "message-parsing"
-            metric-namespaces [service-name "message-parsing"]
+            metric-namespaces [service-name default-namespace]
             multi-namespaces  [metric-namespaces [default-namespace]]]
         (sentry/report-error sentry-reporter e (str "Couldn't parse the message with proto - " proto-class))
         (metrics/multi-ns-increment-count multi-namespaces "failed" additional-tags)

--- a/test/ziggurat/mapper_test.clj
+++ b/test/ziggurat/mapper_test.clj
@@ -17,7 +17,7 @@
         message                         {:foo "bar"}
         stream-routes                   {:default {:handler-fn #(constantly nil)}}
         expected-topic-entity-name      (name (first (keys stream-routes)))
-        expected-additional-tags        {:topic_name expected-topic-entity-name}
+        expected-additional-tags        {:actor service-name :topic_name expected-topic-entity-name}
         default-namespace               "message-processing"
         report-time-namespace           "handler-fn-execution-time"
         expected-metric-namespaces      [expected-topic-entity-name default-namespace]
@@ -123,7 +123,7 @@
                                               :channel-1  #(constantly nil)}}
         topic                      (first (keys stream-routes))
         expected-topic-entity-name (name topic)
-        expected-additional-tags   {:topic_name expected-topic-entity-name}
+        expected-additional-tags   {:actor service-name :topic_name expected-topic-entity-name}
         channel                    :channel-1
         channel-name               (name channel)
         default-namespace          "message-processing"

--- a/test/ziggurat/metrics_test.clj
+++ b/test/ziggurat/metrics_test.clj
@@ -7,14 +7,14 @@
   (testing "returns a meter"
     (let [category "category"
           metric   "metric1"
-          meter    (metrics/mk-meter category metric)]
+          meter    (metrics/mk-meter category metric {:actor "service"})]
       (is (instance? Meter meter)))))
 
 (deftest mk-histogram-test
   (testing "returns a histogram"
     (let [category "category"
           metric   "metric2"
-          meter    (metrics/mk-histogram category metric)]
+          meter    (metrics/mk-histogram category metric {:actor "service"})]
       (is (instance? Histogram meter)))))
 
 (deftest increment-count-test

--- a/test/ziggurat/producer_test.clj
+++ b/test/ziggurat/producer_test.clj
@@ -1,12 +1,12 @@
 (ns ziggurat.producer-test
   (:require [clojure.test :refer :all]
-            [ziggurat.streams :refer [start-streams stop-streams]]
-            [ziggurat.fixtures :as fix :refer [*producer-properties* *consumer-properties*]]
+            [clojure.test.check.generators :as gen]
             [ziggurat.config :refer [ziggurat-config]]
+            [ziggurat.fixtures :as fix :refer [*producer-properties* *consumer-properties*]]
             [ziggurat.producer :refer [producer-properties-map send kafka-producers]]
-            [clojure.test.check.generators :as gen])
-  (:import (org.apache.kafka.streams.integration.utils IntegrationTestUtils)
-           (org.apache.kafka.clients.producer KafkaProducer)))
+            [ziggurat.streams :refer [start-streams stop-streams]])
+  (:import (org.apache.kafka.clients.producer KafkaProducer)
+           (org.apache.kafka.streams.integration.utils IntegrationTestUtils)))
 
 (use-fixtures :once fix/mount-only-config-and-producer)
 
@@ -21,31 +21,30 @@
                                                                              :enabled [true :bool]}}}}})
 
 (deftest send-data-with-topic-and-value-test
-  (with-redefs
-   [kafka-producers (hash-map :default (KafkaProducer. *producer-properties*))]
-    (let [topic (gen/generate gen/string-alphanumeric 10)
-          key "message"
-          value "Hello World!!"]
+  (with-redefs [kafka-producers (hash-map :default (KafkaProducer. *producer-properties*))]
+    (let [alphanum-gen (gen/such-that #(some? %) gen/string-alphanumeric)
+          topic        (gen/generate alphanum-gen 10)
+          key          "message"
+          value        "Hello World!!"]
       (send :default topic key value)
       (let [result (IntegrationTestUtils/waitUntilMinKeyValueRecordsReceived *consumer-properties* topic  1 2000)]
         (is (= value (.value (first result))))))))
 
 (deftest send-data-with-topic-key-partition-and-value-test
-  (with-redefs
-   [kafka-producers (hash-map :default (KafkaProducer. *producer-properties*))]
-    (let [topic (gen/generate gen/string-alphanumeric 10)
-          key "message"
-          value "Hello World!!"
-          partition (int 0)]
+  (with-redefs [kafka-producers (hash-map :default (KafkaProducer. *producer-properties*))]
+    (let [alphanum-gen (gen/such-that #(some? %) gen/string-alphanumeric)
+          topic        (gen/generate alphanum-gen 10)
+          key          "message"
+          value        "Hello World!!"
+          partition    (int 0)]
       (send :default topic partition key value)
       (let [result (IntegrationTestUtils/waitUntilMinKeyValueRecordsReceived *consumer-properties* topic  1 2000)]
         (is (= value (.value (first result))))))))
 
 (deftest send-throws-exception-when-no-producers-are-configured
-  (with-redefs
-   [kafka-producers {}]
+  (with-redefs [kafka-producers {}]
     (let [topic "test-topic"
-          key "message"
+          key   "message"
           value "Hello World!! from non-existant Kafka Producers"]
       (is (not-empty (try (send :default topic key value)
                           (catch Exception e (ex-data e))))))))
@@ -53,14 +52,10 @@
 (deftest producer-properties-map-is-empty-if-no-producers-configured
   ; Here ziggurat-config has been substituted with a custom map which
   ; does not have any valid producer configs.
-  (with-redefs
-   [ziggurat-config stream-router-config-without-producer]
+  (with-redefs [ziggurat-config stream-router-config-without-producer]
     (is (empty? (producer-properties-map)))))
 
 (deftest producer-properties-map-is-not-empty-if-producers-are-configured
   ; Here the config is read from config.test.edn which contains
   ; valid producer configs.
   (is (seq (producer-properties-map))))
-
-
-

--- a/test/ziggurat/streams_test.clj
+++ b/test/ziggurat/streams_test.clj
@@ -1,9 +1,9 @@
 (ns ziggurat.streams-test
   (:require [clojure.test :refer :all]
             [flatland.protobuf.core :as proto]
-            [ziggurat.streams :refer [start-streams stop-streams]]
+            [ziggurat.config :refer [ziggurat-config]]
             [ziggurat.fixtures :as fix]
-            [ziggurat.config :refer [ziggurat-config]])
+            [ziggurat.streams :refer [start-streams stop-streams]])
   (:import [flatland.protobuf.test Example$Photo]
            [java.util Properties]
            [kafka.utils MockTime]


### PR DESCRIPTION
I refactored the inclusion of the actor key/value to be more testable and have more predictable behavior. I basically moved it to when the `additional-tags` is created. With this the `group` atom is not needed anymore. It is now either enforced on the test and on the precondition.

An odd thing happened when I was testing this, does `(gen/string-alphanumeric)` produce nil?