### PR TITLE
move dead set functions into messaging.dead-set namespace

### DIFF
--- a/src/ziggurat/messaging/dead_set.clj
+++ b/src/ziggurat/messaging/dead_set.clj
@@ -1,22 +1,64 @@
 (ns ziggurat.messaging.dead-set
-  (:require [ziggurat.messaging.consumer :as consumer]
-            [ziggurat.messaging.producer :as producer]))
+  (:require [langohr.basic :as lb]
+            [langohr.channel :as lch]
+            [sentry-clj.async :as sentry]
+            [ziggurat.config :refer [get-in-config]]
+            [ziggurat.sentry :refer [sentry-reporter]]
+            [ziggurat.messaging.connection :refer [connection]]
+            [ziggurat.messaging.consumer :as consumer]
+            [ziggurat.messaging.producer :as producer]
+            [ziggurat.messaging.util :refer :all]))
+
+(defn- try-consuming-dead-set-messages [ch ack? queue-name topic-entity]
+  (try
+    (let [[meta payload] (lb/get ch queue-name false)]
+      (when (some? payload)
+        (consumer/convert-and-ack-message ch meta payload ack? topic-entity)))
+    (catch Exception e
+      (sentry/report-error sentry-reporter e "Error while consuming the dead set message"))))
+
+(defn- get-dead-set-messages*
+  "Get the n(count) messages from the rabbitmq.
+
+   If ack is set to true,
+   then ack all the messages while consuming and make them unavailable to other subscribers.
+
+   If ack is false,
+   it will not ack the message."
+  [ack? queue-name count topic-entity]
+  (remove nil?
+          (with-open [ch (lch/open connection)]
+            (doall (for [_ (range count)]
+                     (try-consuming-dead-set-messages ch ack? queue-name topic-entity))))))
+
+(defn get-dead-set-messages-for-topic [ack? topic-entity count]
+  (get-dead-set-messages* ack?
+                          (prefixed-queue-name topic-entity
+                                               (get-in-config [:rabbit-mq :dead-letter :queue-name]))
+                          count
+                          topic-entity))
+
+(defn get-dead-set-messages-for-channel [ack? topic-entity channel count]
+  (get-dead-set-messages* ack?
+                          (prefixed-channel-name topic-entity channel (get-in-config [:rabbit-mq :dead-letter :queue-name]))
+                          count
+                          topic-entity))
 
 (defn replay
   "Gets the message from the queue and puts them to instant queue"
   [count-of-message topic-entity channel]
   (if (nil? channel)
-    (doseq [message-payload (consumer/get-dead-set-messages-for-topic true topic-entity count-of-message)]
+    (doseq [message-payload (get-dead-set-messages-for-topic true topic-entity count-of-message)]
       (producer/publish-to-instant-queue message-payload))
-    (doseq [message-payload (consumer/get-dead-set-messages-for-channel true topic-entity channel count-of-message)]
+    (doseq [message-payload (get-dead-set-messages-for-channel true topic-entity channel count-of-message)]
       (producer/publish-to-channel-instant-queue channel message-payload))))
 
 (defn- get-messages
   "Gets n messages from dead queue and gives the option to ack or un-ack them"
   [count-of-message topic-entity channel ack?]
   (if (nil? channel)
-    (consumer/get-dead-set-messages-for-topic ack? topic-entity count-of-message)
-    (consumer/get-dead-set-messages-for-channel ack? topic-entity channel count-of-message)))
+    (get-dead-set-messages-for-topic ack? topic-entity count-of-message)
+    (get-dead-set-messages-for-channel ack? topic-entity channel count-of-message)))
 
 (defn view
   "Gets n number of messages from dead queue"

--- a/test/ziggurat/messaging/dead_set_test.clj
+++ b/test/ziggurat/messaging/dead_set_test.clj
@@ -1,14 +1,60 @@
 (ns ziggurat.messaging.dead-set-test
   (:require [clojure.test :refer :all]
             [ziggurat.fixtures :as fix]
-            [ziggurat.messaging.dead-set :as ds]
+            [ziggurat.messaging.dead-set :refer :all]
             [ziggurat.messaging.producer :as producer]
             [ziggurat.util.rabbitmq :as rmq]))
+
+(defn- gen-message-payload [topic-entity]
+  {:message {:gen-key (apply str (take 10 (repeatedly #(char (+ (rand 26) 65)))))}
+   :topic-entity topic-entity})
 
 (use-fixtures :once fix/init-rabbit-mq)
 
 (def topic-entity :default)
 (def default-message-payload {:message {:foo "bar"} :topic-entity topic-entity :retry-count 0})
+
+(deftest get-dead-set-messages-for-topic-test
+  (let [message-payload   (assoc (gen-message-payload topic-entity) :retry-count 0)]
+    (testing "when ack is enabled, get the dead set messages and remove from dead set"
+      (fix/with-queues {topic-entity {:handler-fn (constantly nil)}}
+        (let [count-of-messages 10
+              pushed-message    (doseq [_ (range count-of-messages)]
+                                  (producer/publish-to-dead-queue message-payload))
+              dead-set-messages (get-dead-set-messages-for-topic true topic-entity count-of-messages)]
+          (is (= (repeat count-of-messages message-payload) dead-set-messages))
+          (is (empty? (get-dead-set-messages-for-topic true topic-entity count-of-messages))))))
+
+    (testing "when ack is disabled, get the dead set messages and not remove from dead set"
+      (fix/with-queues {topic-entity {:handler-fn (constantly nil)}}
+        (let [count-of-messages 10
+              pushed-message    (doseq [_ (range count-of-messages)]
+                                  (producer/publish-to-dead-queue message-payload))
+              dead-set-messages (get-dead-set-messages-for-topic false topic-entity count-of-messages)]
+          (is (= (repeat count-of-messages message-payload) dead-set-messages))
+          (is (= (repeat count-of-messages message-payload) (get-dead-set-messages-for-topic false topic-entity count-of-messages))))))))
+
+(deftest get-dead-set-messages-from-channel-test
+  (let [message-payload (assoc (gen-message-payload topic-entity) :retry-count 0)]
+    (testing "when ack is enabled, get the dead set messages and remove from dead set"
+      (fix/with-queues {topic-entity {:handler-fn (constantly nil)
+                                      :channel-1  (constantly nil)}}
+        (let [count-of-messages 10
+              channel           "channel-1"
+              pushed-message    (doseq [_ (range count-of-messages)]
+                                  (producer/publish-to-channel-dead-queue channel message-payload))
+              dead-set-messages (get-dead-set-messages-for-channel true topic-entity channel count-of-messages)]
+          (is (= (repeat count-of-messages message-payload) dead-set-messages))
+          (is (empty? (get-dead-set-messages-for-channel true topic-entity channel count-of-messages))))))
+
+    (testing "when ack is disabled, get the dead set messages and not remove from dead set"
+      (fix/with-queues {topic-entity {:handler-fn #(constantly nil)}}
+        (let [count-of-messages 10
+              pushed-message    (doseq [_ (range count-of-messages)]
+                                  (producer/publish-to-dead-queue message-payload))
+              dead-set-messages (get-dead-set-messages-for-topic false topic-entity count-of-messages)]
+          (is (= (repeat count-of-messages message-payload) dead-set-messages))
+          (is (= (repeat count-of-messages message-payload) (get-dead-set-messages-for-topic false topic-entity count-of-messages))))))))
 
 (deftest replay-test
   (testing "puts message from dead set to instant queue"
@@ -17,7 +63,7 @@
             message-payload   default-message-payload]
         (doseq [_ (range count-of-messages)]
           (producer/publish-to-dead-queue message-payload))
-        (ds/replay count-of-messages topic-entity nil)
+        (replay count-of-messages topic-entity nil)
         (doseq [_ (range count-of-messages)]
           (is (= message-payload (rmq/get-msg-from-instant-queue (name topic-entity)))))
         (is (not (rmq/get-msg-from-instant-queue (name topic-entity)))))))
@@ -30,7 +76,7 @@
             channel           "channel-1"]
         (doseq [_ (range count-of-messages)]
           (producer/publish-to-channel-dead-queue channel message-payload))
-        (ds/replay count-of-messages topic-entity channel)
+        (replay count-of-messages topic-entity channel)
         (doseq [_ (range count-of-messages)]
           (is (= message-payload (rmq/get-message-from-channel-instant-queue (name topic-entity) channel))))
         (is (not (rmq/get-message-from-channel-instant-queue topic-entity channel)))))))
@@ -42,7 +88,7 @@
             message-payload   default-message-payload
             _                 (doseq [_ (range count-of-messages)]
                                 (producer/publish-to-dead-queue message-payload))
-            dead-set-messages (ds/view count-of-messages topic-entity nil)]
+            dead-set-messages (view count-of-messages topic-entity nil)]
         (doseq [dead-set-message dead-set-messages]
           (is (= message-payload dead-set-message)))
         (is (not (empty? (rmq/get-msg-from-dead-queue (name topic-entity))))))))
@@ -55,7 +101,7 @@
             channel           "channel-1"
             _                 (doseq [_ (range count-of-messages)]
                                 (producer/publish-to-channel-dead-queue channel message-payload))
-            dead-set-messages (ds/view count-of-messages topic-entity channel)]
+            dead-set-messages (view count-of-messages topic-entity channel)]
         (doseq [dead-set-message dead-set-messages]
           (is (= message-payload dead-set-message)))
         (is (not (empty? (rmq/get-msg-from-channel-dead-queue (name topic-entity) channel))))))))
@@ -71,8 +117,8 @@
             delete-count            (- count-of-messages remaining-message-count)
             _                       (doseq [message message-payloads]
                                       (producer/publish-to-dead-queue message))
-            _                       (ds/delete delete-count topic-entity nil)
-            dead-set-messages       (ds/view count-of-messages topic-entity nil)]
+            _                       (delete delete-count topic-entity nil)
+            dead-set-messages       (view count-of-messages topic-entity nil)]
 
         (is (= (count dead-set-messages) remaining-message-count))
         (is (= dead-set-messages (take-last remaining-message-count message-payloads))))))
@@ -83,7 +129,7 @@
             message-payload   default-message-payload]
         (doseq [_ (range count-of-messages)]
           (producer/publish-to-dead-queue message-payload))
-        (ds/delete count-of-messages topic-entity nil)
+        (delete count-of-messages topic-entity nil)
         (is (empty? (rmq/get-msg-from-dead-queue (name topic-entity)))))))
 
   (testing "deletes all messages from the dead set from a channel queue"
@@ -94,5 +140,5 @@
             channel-name      "channel-1"]
         (doseq [_ (range count-of-messages)]
           (producer/publish-to-channel-dead-queue channel-name message-payload))
-        (ds/delete count-of-messages topic-entity channel-name)
+        (delete count-of-messages topic-entity channel-name)
         (is (empty? (rmq/get-msg-from-channel-dead-queue (name topic-entity) channel-name)))))))


### PR DESCRIPTION
 move dead set functions into `messaging.dead-set` namespace