### PR TITLE
Removes conflicting dependencies from ziggurat

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -15,17 +15,16 @@
                  [com.taoensso/nippy "2.14.0"]
                  [io.dropwizard.metrics5/metrics-core "5.0.0-rc2" :scope "compile"]
                  [medley "1.2.0"]
-                 [mount "0.1.10"]
+                 [mount "0.1.16"]
                  [org.apache.httpcomponents/fluent-hc "4.5.4"]
                  [org.apache.kafka/kafka-streams "2.1.0" :exclusions [org.slf4j/slf4j-log4j12 log4j]]
-                 [org.apache.logging.log4j/log4j-core "2.7"]
-                 [org.apache.logging.log4j/log4j-slf4j-impl "2.7"]
+                 [org.apache.logging.log4j/log4j-core "2.12.1"]
+                 [org.apache.logging.log4j/log4j-slf4j-impl "2.12.1"]
                  [org.clojure/clojure "1.10.0"]
-                 [org.clojure/data.json "0.2.6"]
-                 [org.clojure/tools.logging "0.3.1"]
-                 [org.clojure/tools.nrepl "0.2.12"]
+                 [org.clojure/tools.logging "0.5.0"]
+                 [org.clojure/tools.nrepl "0.2.13"]
                  [org.flatland/protobuf "0.8.1"]
-                 [prismatic/schema "1.1.9"]
+                 [prismatic/schema "1.1.12"]
                  [ring/ring "1.6.3"]
                  [ring/ring-core "1.6.3"]
                  [ring/ring-defaults "0.3.1"]
@@ -33,7 +32,7 @@
                  [ring/ring-json "0.4.0"]
                  [ring-logger "0.7.7"]
                  [tech.gojek/sentry-clj.async "1.0.0"]
-                 [yleisradio/new-reliquary "1.0.0"]]
+                 [yleisradio/new-reliquary "1.1.0"]]
   :deploy-repositories [["clojars" {:url "https://clojars.org/repo"
                                       :username :env/clojars_username
                                       :password :env/clojars_password
@@ -45,7 +44,7 @@
   :profiles {:uberjar {:aot         :all
                        :global-vars {*warn-on-reflection* true}}
              :test    {:jvm-opts     ["-Dlog4j.configurationFile=resources/log4j2.test.xml"]
-                       :dependencies [[com.google.protobuf/protobuf-java "3.5.1"]
+                       :dependencies [[com.google.protobuf/protobuf-java "3.9.1"]
                                       [io.confluent/kafka-schema-registry "4.1.1"]
                                       [junit/junit "4.12"]
                                       [org.apache.kafka/kafka-streams "2.1.0" :classifier "test" :exclusions [org.slf4j/slf4j-log4j12 log4j]]

--- a/project.clj
+++ b/project.clj
@@ -10,11 +10,11 @@
                  [clj-http "3.10.0"]
                  [com.cemerick/url "0.1.1"]
                  [com.datadoghq/java-dogstatsd-client "2.4"]
-                 [com.fasterxml.jackson.core/jackson-databind "2.9.3"]
-                 [com.novemberain/langohr "5.1.0"]
+                 [com.fasterxml.jackson.core/jackson-databind "2.9.9"]
+                 [com.novemberain/langohr "5.1.0" :exclusions [org.clojure/clojure]]
                  [com.taoensso/nippy "2.14.0"]
                  [io.dropwizard.metrics5/metrics-core "5.0.0-rc2" :scope "compile"]
-                 [medley "1.2.0"]
+                 [medley "1.2.0" :exclusions [org.clojure/clojure]]
                  [mount "0.1.16"]
                  [org.apache.httpcomponents/fluent-hc "4.5.4"]
                  [org.apache.kafka/kafka-streams "2.1.0" :exclusions [org.slf4j/slf4j-log4j12 log4j]]
@@ -25,33 +25,35 @@
                  [org.clojure/tools.nrepl "0.2.13"]
                  [org.flatland/protobuf "0.8.1"]
                  [prismatic/schema "1.1.12"]
-                 [ring/ring "1.6.3"]
-                 [ring/ring-core "1.6.3"]
-                 [ring/ring-defaults "0.3.1"]
-                 [ring/ring-jetty-adapter "1.6.3"]
+                 [ring/ring "1.7.1"]
+                 [ring/ring-core "1.7.1"]
+                 [ring/ring-defaults "0.3.2"]
+                 [ring/ring-jetty-adapter "1.7.1"]
                  [ring/ring-json "0.4.0"]
                  [ring-logger "0.7.7"]
-                 [tech.gojek/sentry-clj.async "1.0.0"]
-                 [yleisradio/new-reliquary "1.1.0"]]
+                 [tech.gojek/sentry-clj.async "1.0.0" :exclusions [org.clojure/clojure]]
+                 [yleisradio/new-reliquary "1.1.0" :exclusions [org.clojure/clojure]]]
   :deploy-repositories [["clojars" {:url "https://clojars.org/repo"
                                       :username :env/clojars_username
                                       :password :env/clojars_password
                                       :sign-releases false}]]
+  :pedantic? :abort
   :java-source-paths ["src/com"]
   :aliases {"test-all"                   ["with-profile" "default:+1.8:+1.9" "test"]
             "code-coverage"              ["with-profile" "test" "cloverage" "--output" "coverage" "--coveralls"]}
   :aot [ziggurat.init ziggurat.config ziggurat.producer ziggurat.sentry ziggurat.metrics ziggurat.fixtures]
   :profiles {:uberjar {:aot         :all
-                       :global-vars {*warn-on-reflection* true}}
+                       :global-vars {*warn-on-reflection* true}
+                       :pedantic? :abort}
              :test    {:jvm-opts     ["-Dlog4j.configurationFile=resources/log4j2.test.xml"]
                        :dependencies [[com.google.protobuf/protobuf-java "3.9.1"]
-                                      [io.confluent/kafka-schema-registry "4.1.1"]
+                                      [io.confluent/kafka-schema-registry "4.1.1" :exclusions [javax.ws.rs/javax.ws.rs-api com.fasterxml.jackson.core/jackson-annotations]]
                                       [junit/junit "4.12"]
                                       [org.apache.kafka/kafka-streams "2.1.0" :classifier "test" :exclusions [org.slf4j/slf4j-log4j12 log4j]]
                                       [org.apache.kafka/kafka-clients "2.1.0" :classifier "test"]
                                       [org.apache.kafka/kafka_2.11 "2.1.0" :classifier "test"]
                                       [org.clojure/test.check "0.9.0"]]
-                       :plugins      [[lein-cloverage "1.0.13"]]
+                       :plugins      [[lein-cloverage "1.0.13" :exclusions [org.clojure/clojure]]]
                        :repositories [["confluent-repo" "https://packages.confluent.io/maven/"]]}
              :dev     {:plugins [[lein-cljfmt "0.6.4"]
                                  [lein-cloverage "1.0.13"]

--- a/project.clj
+++ b/project.clj
@@ -37,7 +37,7 @@
                                       :username :env/clojars_username
                                       :password :env/clojars_password
                                       :sign-releases false}]]
-  :pedantic? :abort
+  :pedantic? :warn
   :java-source-paths ["src/com"]
   :aliases {"test-all"                   ["with-profile" "default:+1.8:+1.9" "test"]
             "code-coverage"              ["with-profile" "test" "cloverage" "--output" "coverage" "--coveralls"]}

--- a/project.clj
+++ b/project.clj
@@ -3,15 +3,15 @@
   :url "https://github.com/gojektech/ziggurat"
   :license {:name "Apache License, Version 2.0"
             :url  "https://www.apache.org/licenses/LICENSE-2.0"}
-  :dependencies [[bidi "2.1.4"]
+  :dependencies [[bidi "2.1.6"]
                  [camel-snake-kebab "0.4.0"]
-                 [cheshire "5.8.1"]
+                 [cheshire "5.9.0"]
                  [clonfig "0.2.0"]
-                 [clj-http "3.7.0"]
+                 [clj-http "3.10.0"]
                  [com.cemerick/url "0.1.1"]
                  [com.datadoghq/java-dogstatsd-client "2.4"]
                  [com.fasterxml.jackson.core/jackson-databind "2.9.3"]
-                 [com.novemberain/langohr "5.0.0"]
+                 [com.novemberain/langohr "5.1.0"]
                  [com.taoensso/nippy "2.14.0"]
                  [io.dropwizard.metrics5/metrics-core "5.0.0-rc2" :scope "compile"]
                  [medley "0.8.4"]
@@ -54,8 +54,8 @@
                                       [org.clojure/test.check "0.9.0"]]
                        :plugins      [[lein-cloverage "1.0.13"]]
                        :repositories [["confluent-repo" "https://packages.confluent.io/maven/"]]}
-             :dev     {:plugins  [[lein-cljfmt "0.6.3"]
-                                  [lein-cloverage "1.0.13"]
-                                  [lein-kibit "0.1.6"]]}
+             :dev     {:plugins [[lein-cljfmt "0.6.4"]
+                                 [lein-cloverage "1.0.13"]
+                                 [lein-kibit "0.1.7" :exclusions [org.clojure/tools.cli rewrite-clj org.clojure/tools.reader]]]}
              :1.9     {:dependencies [[org.clojure/clojure "1.9.0"]]}
              :1.8     {:dependencies [[org.clojure/clojure "1.8.0"]]}})

--- a/project.clj
+++ b/project.clj
@@ -14,7 +14,7 @@
                  [com.novemberain/langohr "5.1.0"]
                  [com.taoensso/nippy "2.14.0"]
                  [io.dropwizard.metrics5/metrics-core "5.0.0-rc2" :scope "compile"]
-                 [medley "0.8.4"]
+                 [medley "1.2.0"]
                  [mount "0.1.10"]
                  [org.apache.httpcomponents/fluent-hc "4.5.4"]
                  [org.apache.kafka/kafka-streams "2.1.0" :exclusions [org.slf4j/slf4j-log4j12 log4j]]

--- a/src/ziggurat/nrepl_server.clj
+++ b/src/ziggurat/nrepl_server.clj
@@ -7,7 +7,7 @@
 (defn- start []
   (let [port (-> (ziggurat-config) :nrepl-server :port)]
     (log/info "Starting nREPL server on port:" port)
-    (nrepl/start-server :port port)))
+    (nrepl/start-server :port port :bind "0.0.0.0")))
 
 (defn- stop [server]
   (nrepl/stop-server server)


### PR DESCRIPTION
There were a lot of transitive dependencies that were being overwritten which could eventually cause dependency conflicts.
So, I have updated all the dependencies to their latest version and also removed these overrides.
So now essentially, only 1 version of every library is loaded into the classpath.

I have also added a check where the uberjar will fail if there is an override happening in libraries.