### PR TITLE
Making key and value serdes configurable for enabling JSON (de)serialization

### DIFF
--- a/resources/config.test.ci.edn
+++ b/resources/config.test.ci.edn
@@ -28,28 +28,48 @@
                                    :enabled [true :bool]}
             :http-server          {:port         [8010 :int]
                                    :thread-count [100 :int]}
-            :stream-router        {:default          {:application-id       "test"
-                                                      :bootstrap-servers    "localhost:9092"
-                                                      :stream-threads-count [1 :int]
-                                                      :origin-topic         "topic"
-                                                      :upgrade-from         "1.1"
-                                                      :channels             {:channel-1 {:worker-count [10 :int]
-                                                                                         :retry        {:count   [5 :int]
-                                                                                                        :enabled [true :bool]}}}
-                                                      :producer             {:bootstrap-servers                     "localhost:9092"
-                                                                             :acks                                  "all"
-                                                                             :retries-config                        5
-                                                                             :max-in-flight-requests-per-connection 5
-                                                                             :enable-idempotence                    false
-                                                                             :value-serializer                      "org.apache.kafka.common.serialization.StringSerializer"
-                                                                             :key-serializer                        "org.apache.kafka.common.serialization.StringSerializer"}}
-                                   :without-producer {:application-id       "test"
-                                                      :bootstrap-servers    "localhost:9092"
-                                                      :stream-threads-count [1 :int]
-                                                      :origin-topic         "topic"
-                                                      :channels             {:channel-1 {:worker-count [10 :int]
-                                                                                         :retry        {:count   [5 :int]
-                                                                                                        :enabled [true :bool]}}}}}
+            :stream-router        {:default                      {:application-id       "test"
+                                                                  :bootstrap-servers    "localhost:9092"
+                                                                  :stream-threads-count [1 :int]
+                                                                  :origin-topic         "topic"
+                                                                  :upgrade-from         "1.1"
+                                                                  :channels             {:channel-1 {:worker-count [10 :int]
+                                                                                                     :retry        {:count   [5 :int]
+                                                                                                                    :enabled [true :bool]}}}
+                                                                  :producer             {:bootstrap-servers                     "localhost:9092"
+                                                                                         :acks                                  "all"
+                                                                                         :retries-config                        5
+                                                                                         :max-in-flight-requests-per-connection 5
+                                                                                         :enable-idempotence                    false
+                                                                                         :value-serializer                      "org.apache.kafka.common.serialization.StringSerializer"
+                                                                                         :key-serializer                        "org.apache.kafka.common.serialization.StringSerializer"}}
+                                   :with-key-val-serdes          {:application-id             "test"
+                                                                  :bootstrap-servers          "localhost:9092"
+                                                                  :stream-threads-count       [1 :int]
+                                                                  :origin-topic               "topic"
+                                                                  :default-key-serde          "org.apache.kafka.common.serialization.Serdes$StringSerde"
+                                                                  :default-value-serde        "org.apache.kafka.common.serialization.Serdes$StringSerde"
+                                                                  :key-deserializer-encoding    "UTF8"
+                                                                  :value-deserializer-encoding  "UTF8"
+                                                                  :upgrade-from               "1.1"
+                                                                  :channels                   {:channel-1 {:worker-count [10 :int]
+                                                                                                           :retry        {:count   [5 :int]
+                                                                                                                          :enabled [true :bool]}}}
+                                                                  :producer                   {:bootstrap-servers                     "localhost:9092"
+                                                                                               :acks                                  "all"
+                                                                                               :retries-config                        5
+                                                                                               :max-in-flight-requests-per-connection 5
+                                                                                               :enable-idempotence                    false
+                                                                                               :value-serializer                      "org.apache.kafka.common.serialization.StringSerializer"
+                                                                                               :key-serializer                        "org.apache.kafka.common.serialization.StringSerializer"}}
+
+                                   :without-producer             {:application-id       "test"
+                                                                  :bootstrap-servers    "localhost:9092"
+                                                                  :stream-threads-count [1 :int]
+                                                                  :origin-topic         "topic"
+                                                                  :channels             {:channel-1 {:worker-count [10 :int]
+                                                                                                     :retry        {:count   [5 :int]
+                                                                                                                    :enabled [true :bool]}}}}}
             :tracer               {:enabled               [true :bool]
                                    :custom-provider       ""}}}
 

--- a/resources/config.test.edn
+++ b/resources/config.test.edn
@@ -28,31 +28,14 @@
                                    :enabled [true :bool]}
             :http-server          {:port         [8010 :int]
                                    :thread-count [100 :int]}
-            :stream-router        {:default          {:application-id       "test"
-                                                      :bootstrap-servers    "localhost:9092"
-                                                      :stream-threads-count [1 :int]
-                                                      :origin-topic         "topic"
-                                                      :upgrade-from         "1.1"
-                                                      :channels             {:channel-1 {:worker-count [10 :int]
-                                                                                         :retry        {:count   [5 :int]
-                                                                                                        :enabled [true :bool]}}}
-                                                      :producer             {:bootstrap-servers                     "localhost:9092"
-                                                                             :acks                                  "all"
-                                                                             :retries-config                        5
-                                                                             :max-in-flight-requests-per-connection 5
-                                                                             :enable-idempotence                    false
-                                                                             :value-serializer                      "org.apache.kafka.common.serialization.StringSerializer"
-                                                                             :key-serializer                        "org.apache.kafka.common.serialization.StringSerializer"}}
-                                   :with-key-val-serdes          {:application-id       "test"
+            :stream-router        {:default                      {:application-id       "test"
                                                                   :bootstrap-servers    "localhost:9092"
                                                                   :stream-threads-count [1 :int]
                                                                   :origin-topic         "topic"
-                                                                  :default-key-serde    "org.apache.kafka.common.serialization.Serdes$StringSerde"
-                                                                  :default-value-serde  "org.apache.kafka.common.serialization.Serdes$StringSerde"
                                                                   :upgrade-from         "1.1"
                                                                   :channels             {:channel-1 {:worker-count [10 :int]
-                                                                                         :retry        {:count   [5 :int]
-                                                                                                        :enabled [true :bool]}}}
+                                                                                                     :retry        {:count   [5 :int]
+                                                                                                                    :enabled [true :bool]}}}
                                                                   :producer             {:bootstrap-servers                     "localhost:9092"
                                                                                          :acks                                  "all"
                                                                                          :retries-config                        5
@@ -60,12 +43,31 @@
                                                                                          :enable-idempotence                    false
                                                                                          :value-serializer                      "org.apache.kafka.common.serialization.StringSerializer"
                                                                                          :key-serializer                        "org.apache.kafka.common.serialization.StringSerializer"}}
-                                   :without-producer {:application-id       "test"
-                                                      :bootstrap-servers    "localhost:9092"
-                                                      :stream-threads-count [1 :int]
-                                                      :origin-topic         "topic"
-                                                      :channels             {:channel-1 {:worker-count [10 :int]
-                                                                                         :retry        {:count   [5 :int]
-                                                                                                        :enabled [true :bool]}}}}}
+                                   :with-key-val-serdes          {:application-id             "test"
+                                                                  :bootstrap-servers          "localhost:9092"
+                                                                  :stream-threads-count       [1 :int]
+                                                                  :origin-topic               "topic"
+                                                                  :default-key-serde          "org.apache.kafka.common.serialization.Serdes$StringSerde"
+                                                                  :default-value-serde        "org.apache.kafka.common.serialization.Serdes$StringSerde"
+                                                                  :key-deserializer-encoding    "UTF8"
+                                                                  :value-deserializer-encoding  "UTF8"
+                                                                  :upgrade-from               "1.1"
+                                                                  :channels                   {:channel-1 {:worker-count [10 :int]
+                                                                                               :retry        {:count   [5 :int]
+                                                                                                        :enabled [true :bool]}}}
+                                                                  :producer                   {:bootstrap-servers                     "localhost:9092"
+                                                                                               :acks                                  "all"
+                                                                                               :retries-config                        5
+                                                                                               :max-in-flight-requests-per-connection 5
+                                                                                               :enable-idempotence                    false
+                                                                                               :value-serializer                      "org.apache.kafka.common.serialization.StringSerializer"
+                                                                                               :key-serializer                        "org.apache.kafka.common.serialization.StringSerializer"}}
+                                   :without-producer             {:application-id       "test"
+                                                                  :bootstrap-servers    "localhost:9092"
+                                                                  :stream-threads-count [1 :int]
+                                                                  :origin-topic         "topic"
+                                                                  :channels             {:channel-1 {:worker-count [10 :int]
+                                                                                                     :retry        {:count   [5 :int]
+                                                                                                                    :enabled [true :bool]}}}}}
             :tracer               {:enabled               [true :bool]
                                    :custom-provider       ""}}}

--- a/resources/config.test.edn
+++ b/resources/config.test.edn
@@ -43,6 +43,23 @@
                                                                              :enable-idempotence                    false
                                                                              :value-serializer                      "org.apache.kafka.common.serialization.StringSerializer"
                                                                              :key-serializer                        "org.apache.kafka.common.serialization.StringSerializer"}}
+                                   :with-key-val-serdes          {:application-id       "test"
+                                                                  :bootstrap-servers    "localhost:9092"
+                                                                  :stream-threads-count [1 :int]
+                                                                  :origin-topic         "topic"
+                                                                  :default-key-serde    "org.apache.kafka.common.serialization.Serdes$StringSerde"
+                                                                  :default-value-serde  "org.apache.kafka.common.serialization.Serdes$StringSerde"
+                                                                  :upgrade-from         "1.1"
+                                                                  :channels             {:channel-1 {:worker-count [10 :int]
+                                                                                         :retry        {:count   [5 :int]
+                                                                                                        :enabled [true :bool]}}}
+                                                                  :producer             {:bootstrap-servers                     "localhost:9092"
+                                                                                         :acks                                  "all"
+                                                                                         :retries-config                        5
+                                                                                         :max-in-flight-requests-per-connection 5
+                                                                                         :enable-idempotence                    false
+                                                                                         :value-serializer                      "org.apache.kafka.common.serialization.StringSerializer"
+                                                                                         :key-serializer                        "org.apache.kafka.common.serialization.StringSerializer"}}
                                    :without-producer {:application-id       "test"
                                                       :bootstrap-servers    "localhost:9092"
                                                       :stream-threads-count [1 :int]

--- a/src/ziggurat/middleware/json.clj
+++ b/src/ziggurat/middleware/json.clj
@@ -1,0 +1,45 @@
+(ns ziggurat.middleware.json
+  "This namespace defines middleware methods for parsing JSON strings.
+   Please see [Ziggurat Middleware](https://github.com/gojek/ziggurat#middleware-in-ziggurat) for more details.
+  "
+  (:require [cheshire.core :refer :all]
+            [sentry-clj.async :as sentry]
+            [ziggurat.sentry :refer [sentry-reporter]]
+            [ziggurat.metrics :as metrics]))
+
+(defn- deserialize-json
+  [message topic-entity-name key-fn]
+  (try
+    (parse-string message key-fn)
+    (catch Exception e
+      (let [additional-tags   {:topic_name topic-entity-name}
+            default-namespace "json-message-parsing"]
+        (sentry/report-error sentry-reporter e (str "Could not parse JSON message " message))
+        (metrics/increment-count default-namespace "failed" additional-tags)
+        nil))))
+
+(defn parse-json
+  "This method returns a function which deserializes the provided message before processing it.
+   It uses `deserialize-json` defined in this namespace to parse JSON strings.
+
+   Takes following arguments:
+   `handler-fn`        : A function which would process the parsed JSON string
+   `topic-entity-name` : Stream route topic entity (as defined in config.edn). It is only used for publishing metrics.
+   `key-fn`            : key-fn can be either true, false of a generic function to transform keys in JSON string.
+                         If `true`, would coerce keys to keywords, and if `false` it would leave keys as strings.
+                         Default value is true.
+
+   An Example
+   For parsing a JSON string `\"{\"foo\":\"bar\"}\"` to `{\"foo\":\"bar\"}`, call the function with `key-fn` false
+   `(parse-json (fn [message] ()) \"topic\" false)`
+
+   For parsing a JSON string `\"{\"foo\":\"bar\"}\"` to `{:foo:\"bar\"}`, call the function without passing `key-fn`,
+   whose default value is true.
+   `(parse-json (fn [message] ()) \"topic\")`
+
+   "
+  ([handler-fn topic-entity-name]
+   (parse-json handler-fn topic-entity-name true))
+  ([handler-fn topic-entity-name key-fn]
+   (fn [message]
+     (handler-fn (deserialize-json message topic-entity-name key-fn)))))

--- a/src/ziggurat/streams.clj
+++ b/src/ziggurat/streams.clj
@@ -44,6 +44,9 @@
   (if-not (contains? #{"latest" "earliest" nil} auto-offset-reset-config)
     (throw (ex-info "Stream offset can only be latest or earliest" {:offset auto-offset-reset-config}))))
 
+(defn- get-serde [default-serde]
+  (if (some? default-serde) default-serde (.getName (.getClass (Serdes/ByteArray)))))
+
 (defn- properties [{:keys [application-id
                            bootstrap-servers
                            stream-threads-count
@@ -51,14 +54,16 @@
                            buffered-records-per-partition
                            commit-interval-ms
                            upgrade-from
-                           changelog-topic-replication-factor]}]
+                           changelog-topic-replication-factor
+                           default-key-serde
+                           default-value-serde]}]
   (validate-auto-offset-reset-config auto-offset-reset-config)
   (doto (Properties.)
     (.put StreamsConfig/APPLICATION_ID_CONFIG application-id)
     (.put StreamsConfig/BOOTSTRAP_SERVERS_CONFIG bootstrap-servers)
     (.put StreamsConfig/NUM_STREAM_THREADS_CONFIG (int stream-threads-count))
-    (.put StreamsConfig/DEFAULT_KEY_SERDE_CLASS_CONFIG (.getName (.getClass (Serdes/ByteArray))))
-    (.put StreamsConfig/DEFAULT_VALUE_SERDE_CLASS_CONFIG (.getName (.getClass (Serdes/ByteArray))))
+    (.put StreamsConfig/DEFAULT_KEY_SERDE_CLASS_CONFIG (get-serde default-key-serde))
+    (.put StreamsConfig/DEFAULT_VALUE_SERDE_CLASS_CONFIG (get-serde default-value-serde))
     (.put StreamsConfig/DEFAULT_TIMESTAMP_EXTRACTOR_CLASS_CONFIG IngestionTimeExtractor)
     (.put StreamsConfig/BUFFERED_RECORDS_PER_PARTITION_CONFIG (int buffered-records-per-partition))
     (.put StreamsConfig/COMMIT_INTERVAL_MS_CONFIG commit-interval-ms)

--- a/test/ziggurat/middleware/json_test.clj
+++ b/test/ziggurat/middleware/json_test.clj
@@ -1,0 +1,59 @@
+(ns ziggurat.middleware.json-test
+  (:require [clojure.test :refer :all]
+            [cheshire.core :refer [generate-string]]
+            [ziggurat.middleware.json :refer [parse-json]]
+            [ziggurat.fixtures :as fix]
+            [ziggurat.metrics :as metrics]))
+
+(use-fixtures :once (join-fixtures [fix/mount-only-config
+                                    fix/silence-logging]))
+
+(deftest parse-json-test
+  (testing "Given a handler function (without passing key-fn), parse-json should call that function on after deserializing the string to JSON object."
+    (let [handler-fn-called? (atom false)
+          message            {:a "A"
+                              :b "B"}
+          topic-entity-name  "test"
+          handler-fn         (fn [msg]
+                               (if (= msg message)
+                                 (reset! handler-fn-called? true)))]
+      ((parse-json handler-fn topic-entity-name) (generate-string message))
+      (is (true? @handler-fn-called?))))
+  (testing "Given a handler function and key-fn as false, parse-json should call that function on after
+            deserializing the string without coercing the keys to keywords."
+    (let [handler-fn-called? (atom false)
+          message            {:a "A"
+                              :b "B"}
+          expected-output    {"a" "A" "b" "B"}
+          topic-entity-name  "test"
+          handler-fn         (fn [msg]
+                               (if (= msg expected-output)
+                                 (reset! handler-fn-called? true)))]
+      ((parse-json handler-fn topic-entity-name false) (generate-string message))
+      (is (true? @handler-fn-called?))))
+  (testing "Given a handler function and a key-fn, parse-json should call that function after
+            deserializing the string by applying key-fn to keys."
+    (let [handler-fn-called? (atom false)
+          key-fn             (fn [k] (str k "-modified"))
+          message            {"a" "A"
+                              "b" "B"}
+          expected-output    {"a-modified" "A" "b-modified" "B"}
+          topic-entity-name  "test"
+          handler-fn         (fn [msg]
+                               (if (= msg expected-output)
+                                 (reset! handler-fn-called? true)))]
+      ((parse-json handler-fn topic-entity-name key-fn) (generate-string message))
+      (is (true? @handler-fn-called?))))
+  (testing "Should report metrics when JSON deserialization fails"
+    (let [handler-fn-called?      (atom false)
+          metric-reporter-called? (atom false)
+          topic-entity-name       "test"
+          message                 "{\"foo\":\"bar"
+          handler-fn              (fn [msg]
+                                    (if (nil? msg)
+                                      (reset! handler-fn-called? true)))]
+      (with-redefs [metrics/increment-count (fn [_ _ _]
+                                              (reset! metric-reporter-called? true))]
+        ((parse-json handler-fn topic-entity-name true) message))
+      (is (true? @handler-fn-called?))
+      (is (true? @metric-reporter-called?)))))


### PR DESCRIPTION
Reverted the earlier commit where byte array message was converted to String before parsing as JSON

Changed streams.clj to accept any serde. Earlier, byte array was hard-coded.