### PR TITLE
Report metrics in old format

### DIFF
--- a/resources/config.test.ci.edn
+++ b/resources/config.test.ci.edn
@@ -35,27 +35,7 @@
                                                           :upgrade-from         "1.1"
                                                           :channels             {:channel-1 {:worker-count [10 :int]
                                                                                              :retry        {:count   [5 :int]
-                                                                                                            :enabled [true :bool]}}
-                                                                                 :channel-delay {:worker-count [10 :int]
-                                                                                                 :retry        {:count   [5 :int]
-                                                                                                                :enabled [true :bool]}
-                                                                                                 :channel-delay-ms [1000 :int]}
-                                                                                 :linear-retry {:worker-count [10 :int]
-                                                                                                :retry        {:count   [5 :int]
-                                                                                                               :enabled [true :bool]
-                                                                                                               :queue-timeout-ms [2000 :int]}}
-                                                                                 :exponential-retry {:worker-count [10 :int]
-                                                                                                     :retry        {:count   [5 :int]
-                                                                                                                    :enabled [true :bool]
-                                                                                                                    :queue-timeout-ms [1000 :int]
-                                                                                                                    :exponential-backoff-enabled [true :bool]}}
-                                                                                 :channel-exponential-retry {:worker-count [10 :int]
-                                                                                                             :retry        {:count   [5 :int]
-                                                                                                                            :enabled [true :bool]
-                                                                                                                            :exponential-backoff-enabled [true :bool]}}
-                                                                                 :channel-no-retry-count {:worker-count [10 :int]
-                                                                                                          :retry        {:enabled [true :bool]
-                                                                                                                         :exponential-backoff-enabled [true :bool]}}}
+                                                                                                            :enabled [true :bool]}}}
                                                           :producer             {:bootstrap-servers                     "localhost:9092"
                                                                                  :acks                                  "all"
                                                                                  :retries-config                        5

--- a/resources/config.test.edn
+++ b/resources/config.test.edn
@@ -35,27 +35,7 @@
                                                           :upgrade-from         "1.1"
                                                           :channels             {:channel-1 {:worker-count [10 :int]
                                                                                              :retry        {:count   [5 :int]
-                                                                                                            :enabled [true :bool]}}
-                                                                                 :channel-delay {:worker-count [10 :int]
-                                                                                                 :retry        {:count   [5 :int]
-                                                                                                                :enabled [true :bool]}
-                                                                                                 :channel-delay-ms [1000 :int]}
-                                                                                 :linear-retry {:worker-count [10 :int]
-                                                                                                :retry        {:count   [5 :int]
-                                                                                                               :enabled [true :bool]
-                                                                                                               :queue-timeout-ms [2000 :int]}}
-                                                                                 :exponential-retry {:worker-count [10 :int]
-                                                                                                     :retry        {:count   [5 :int]
-                                                                                                                    :enabled [true :bool]
-                                                                                                                    :queue-timeout-ms [1000 :int]
-                                                                                                                    :exponential-backoff-enabled [true :bool]}}
-                                                                                 :channel-exponential-retry {:worker-count [10 :int]
-                                                                                                             :retry        {:count   [5 :int]
-                                                                                                                            :enabled [true :bool]
-                                                                                                                            :exponential-backoff-enabled [true :bool]}}
-                                                                                 :channel-no-retry-count {:worker-count [10 :int]
-                                                                                                          :retry        {:enabled [true :bool]
-                                                                                                                         :exponential-backoff-enabled [true :bool]}}}
+                                                                                                            :enabled [true :bool]}}}
                                                           :producer             {:bootstrap-servers                     "localhost:9092"
                                                                                  :acks                                  "all"
                                                                                  :retries-config                        5

--- a/src/ziggurat/kafka_delay.clj
+++ b/src/ziggurat/kafka_delay.clj
@@ -3,9 +3,11 @@
             [ziggurat.util.time :refer :all]))
 
 (defn calculate-and-report-kafka-delay
-  ([metric-namespace record-timestamp]
-   (calculate-and-report-kafka-delay metric-namespace record-timestamp nil))
-  ([metric-namespace record-timestamp additional-tags]
-   (let [now-millis (get-current-time-in-millis)
-         delay      (- now-millis record-timestamp)]
-     (metrics/report-histogram metric-namespace delay additional-tags))))
+  ([metric-namespaces record-timestamp]
+   (calculate-and-report-kafka-delay metric-namespaces record-timestamp nil))
+  ([metric-namespaces record-timestamp additional-tags]
+   (let [now-millis        (get-current-time-in-millis)
+         delay             (- now-millis record-timestamp)
+         default-namespace (last metric-namespaces)
+         multi-namespaces  [metric-namespaces [default-namespace]]]
+     (metrics/multi-ns-report-histogram multi-namespaces delay additional-tags))))

--- a/src/ziggurat/mapper.clj
+++ b/src/ziggurat/mapper.clj
@@ -12,11 +12,7 @@
 (defn- send-msg-to-channel [channels message-payload return-code]
   (when-not (contains? (set channels) return-code)
     (throw (ex-info "Invalid mapper return code" {:code return-code})))
-  (let [topic-entity  (:topic-entity message-payload)
-        channel-delay-ms (get-in (ziggurat-config) [:stream-router topic-entity :channels return-code :channel-delay-ms])]
-    (if channel-delay-ms
-      (producer/publish-to-channel-custom-delay-queue return-code message-payload channel-delay-ms)
-      (producer/publish-to-channel-instant-queue return-code message-payload))))
+  (producer/publish-to-channel-instant-queue return-code message-payload))
 
 (defn mapper-func [mapper-fn channels]
   (fn [{:keys [topic-entity message] :as message-payload}]

--- a/src/ziggurat/mapper.clj
+++ b/src/ziggurat/mapper.clj
@@ -16,74 +16,77 @@
 
 (defn mapper-func [mapper-fn channels]
   (fn [{:keys [topic-entity message] :as message-payload}]
-    (let [service-name               (:app-name (ziggurat-config))
-          topic-entity-name          (name topic-entity)
-          new-relic-transaction-name (str topic-entity-name ".handler-fn")
-          default-namespace          "message-processing"
-          additional-tags            {:topic_name topic-entity-name}
-          success-metric             "success"
-          retry-metric               "retry"
-          skip-metric                "skip"
-          failure-metric             "failure"]
+    (let [service-name                        (:app-name (ziggurat-config))
+          topic-entity-name                   (name topic-entity)
+          new-relic-transaction-name          (str topic-entity-name ".handler-fn")
+          message-processing-namespace        "message-processing"
+          message-processing-namespaces       [service-name topic-entity-name message-processing-namespace]
+          additional-tags                     {:topic_name topic-entity-name}
+          success-metric                      "success"
+          retry-metric                        "retry"
+          skip-metric                         "skip"
+          failure-metric                      "failure"
+          multi-message-processing-namespaces [message-processing-namespaces [message-processing-namespace]]]
       (nr/with-tracing "job" new-relic-transaction-name
         (try
-          (let [start-time               (.toEpochMilli (Instant/now))
-                return-code              (mapper-fn message)
-                end-time                 (.toEpochMilli (Instant/now))
-                time-val                 (- end-time start-time)
-                execution-time-namespace "handler-fn-execution-time"
+          (let [start-time                      (.toEpochMilli (Instant/now))
+                return-code                     (mapper-fn message)
+                end-time                        (.toEpochMilli (Instant/now))
+                time-val                        (- end-time start-time)
+                execution-time-namespace        "handler-fn-execution-time"
                 multi-execution-time-namespaces [[service-name topic-entity-name execution-time-namespace]
                                                  [execution-time-namespace]]]
             (metrics/multi-ns-report-histogram multi-execution-time-namespaces time-val additional-tags)
             (case return-code
-              :success (metrics/increment-count default-namespace success-metric additional-tags)
-              :retry   (do (metrics/increment-count default-namespace retry-metric additional-tags)
+              :success (metrics/multi-ns-increment-count multi-message-processing-namespaces success-metric additional-tags)
+              :retry   (do (metrics/multi-ns-increment-count multi-message-processing-namespaces retry-metric additional-tags)
                            (producer/retry message-payload))
-              :skip    (metrics/increment-count default-namespace skip-metric additional-tags)
+              :skip    (metrics/multi-ns-increment-count multi-message-processing-namespaces skip-metric additional-tags)
               :block   'TODO
               (do
                 (send-msg-to-channel channels message-payload return-code)
-                (metrics/increment-count default-namespace success-metric additional-tags))))
+                (metrics/multi-ns-increment-count multi-message-processing-namespaces success-metric additional-tags))))
           (catch Throwable e
             (producer/retry message-payload)
             (sentry/report-error sentry-reporter e (str "Actor execution failed for " topic-entity-name))
-            (metrics/increment-count default-namespace failure-metric additional-tags)))))))
+            (metrics/multi-ns-increment-count multi-message-processing-namespaces failure-metric additional-tags)))))))
 
 (defn channel-mapper-func [mapper-fn channel]
   (fn [{:keys [topic-entity message] :as message-payload}]
-    (let [service-name      (:app-name (ziggurat-config))
-          topic-entity-name (name topic-entity)
-          channel-name      (name channel)
-          default-namespace "message-processing"
-          base-namespaces   [service-name topic-entity-name channel-name]
-          metric-namespaces (conj base-namespaces default-namespace)
-          additional-tags   {:topic_name topic-entity-name :channel_name channel-name}
-          metric-namespace  (str/join "." metric-namespaces)
-          success-metric    "success"
-          retry-metric      "retry"
-          skip-metric       "skip"
-          failure-metric    "failure"]
+    (let [service-name                        (:app-name (ziggurat-config))
+          topic-entity-name                   (name topic-entity)
+          channel-name                        (name channel)
+          message-processing-namespace        "message-processing"
+          base-namespaces                     [service-name topic-entity-name channel-name]
+          message-processing-namespaces       (conj base-namespaces message-processing-namespace)
+          additional-tags                     {:topic_name topic-entity-name :channel_name channel-name}
+          metric-namespace                    (str/join "." message-processing-namespaces)
+          success-metric                      "success"
+          retry-metric                        "retry"
+          skip-metric                         "skip"
+          failure-metric                      "failure"
+          multi-message-processing-namespaces [message-processing-namespaces [message-processing-namespace]]]
       (nr/with-tracing "job" metric-namespace
         (try
-          (let [start-time               (.toEpochMilli (Instant/now))
-                return-code              (mapper-fn message)
-                end-time                 (.toEpochMilli (Instant/now))
-                time-val                 (- end-time start-time)
-                execution-time-namespace "execution-time"
+          (let [start-time                     (.toEpochMilli (Instant/now))
+                return-code                    (mapper-fn message)
+                end-time                       (.toEpochMilli (Instant/now))
+                time-val                       (- end-time start-time)
+                execution-time-namespace       "execution-time"
                 multi-execution-time-namespace [(conj base-namespaces execution-time-namespace)
                                                 [execution-time-namespace]]]
             (metrics/multi-ns-report-histogram multi-execution-time-namespace time-val additional-tags)
             (case return-code
-              :success (metrics/increment-count default-namespace success-metric additional-tags)
-              :retry   (do (metrics/increment-count default-namespace retry-metric additional-tags)
+              :success (metrics/multi-ns-increment-count multi-message-processing-namespaces success-metric additional-tags)
+              :retry   (do (metrics/multi-ns-increment-count multi-message-processing-namespaces retry-metric additional-tags)
                            (producer/retry-for-channel message-payload channel))
-              :skip    (metrics/increment-count default-namespace skip-metric additional-tags)
+              :skip    (metrics/multi-ns-increment-count multi-message-processing-namespaces skip-metric additional-tags)
               :block   'TODO
               (throw (ex-info "Invalid mapper return code" {:code return-code}))))
           (catch Throwable e
             (producer/retry-for-channel message-payload channel)
             (sentry/report-error sentry-reporter e (str "Channel execution failed for " topic-entity-name " and for channel " channel-name))
-            (metrics/increment-count default-namespace failure-metric additional-tags)))))))
+            (metrics/multi-ns-increment-count multi-message-processing-namespaces failure-metric additional-tags)))))))
 
 (defrecord MessagePayload [message topic-entity])
 

--- a/src/ziggurat/messaging/producer.clj
+++ b/src/ziggurat/messaging/producer.clj
@@ -96,41 +96,8 @@
 (defn- get-channel-retry-count [topic-entity channel]
   (-> (ziggurat-config) :stream-router topic-entity :channels channel :retry :count))
 
-(defn- get-channel-retry-queue-timeout-ms [topic-entity channel]
-  (-> (ziggurat-config) :stream-router topic-entity :channels channel :retry :queue-timeout-ms))
-
-(defn- channel-retries-exponential-backoff-enabled [topic-entity channel]
-  "Get exponential backoff enabled for specific channel from config."
-  (-> (ziggurat-config) :stream-router topic-entity :channels channel :retry :exponential-backoff-enabled))
-
-(defn- get-exponential-backoff [retry-count message-retry-count queue-timeout-ms]
-  "Get queue timeout value when exponential backoff is enabled."
-  (int (* (dec (Math/pow 2 (- retry-count message-retry-count))) queue-timeout-ms)))
-
-(defn get-queue-timeout-ms [topic-entity channel message-payload]
-  "Get queue timeout from config. It will use channel `queue-timeout-ms` if defined, otherwise it will use rabbitmq delay `queue-timeout-ms`.
-   If `exponential-backoff-enabled` is true, `queue-timeout-ms` will be exponential with formula `(2^n)-1`, where `n` is message retry-count.
-
-   _NOTE: Exponential backoff for channel retries is an experimental feature. It should not be used until released in a stable version._"
-  (let [queue-timeout-ms (-> (rabbitmq-config) :delay :queue-timeout-ms)
-        channel-queue-timeout-ms (get-channel-retry-queue-timeout-ms topic-entity channel)
-        exponential-backoff-enabled (channel-retries-exponential-backoff-enabled topic-entity channel)]
-    (if exponential-backoff-enabled
-      (let [retry-count (-> (ziggurat-config) :retry :count)
-            channel-retry-count (get-channel-retry-count topic-entity channel)
-            message-retry-count (:retry-count message-payload)]
-        (get-exponential-backoff (or channel-retry-count retry-count) message-retry-count (or channel-queue-timeout-ms queue-timeout-ms)))
-      (or channel-queue-timeout-ms queue-timeout-ms))))
-
 (defn publish-to-channel-delay-queue [channel message-payload]
   (let [{:keys [exchange-name queue-timeout-ms]} (:delay (rabbitmq-config))
-        topic-entity  (:topic-entity message-payload)
-        exchange-name (prefixed-channel-name topic-entity channel exchange-name)
-        queue-timeout-ms (get-queue-timeout-ms topic-entity channel message-payload)]
-    (publish exchange-name message-payload queue-timeout-ms)))
-
-(defn publish-to-channel-custom-delay-queue [channel message-payload queue-timeout-ms]
-  (let [{:keys [exchange-name]} (:delay (rabbitmq-config))
         topic-entity  (:topic-entity message-payload)
         exchange-name (prefixed-channel-name topic-entity channel exchange-name)]
     (publish exchange-name message-payload queue-timeout-ms)))

--- a/src/ziggurat/metrics.clj
+++ b/src/ziggurat/metrics.clj
@@ -9,16 +9,16 @@
            [io.dropwizard.metrics5 Histogram Meter MetricName MetricRegistry]
            java.util.concurrent.TimeUnit)
   (:gen-class
-    :name tech.gojek.ziggurat.internal.Metrics
-    :methods [^{:static true} [incrementCount [String String] void]
-              ^{:static true} [incrementCount [String String java.util.Map] void]
-              ^{:static true} [decrementCount [String String] void]
-              ^{:static true} [decrementCount [String String java.util.Map] void]
-              ^{:static true} [reportTime [String long] void]
-              ^{:static true} [reportTime [String long java.util.Map] void]]))
+   :name tech.gojek.ziggurat.internal.Metrics
+   :methods [^{:static true} [incrementCount [String String] void]
+             ^{:static true} [incrementCount [String String java.util.Map] void]
+             ^{:static true} [decrementCount [String String] void]
+             ^{:static true} [decrementCount [String String java.util.Map] void]
+             ^{:static true} [reportTime [String long] void]
+             ^{:static true} [reportTime [String long java.util.Map] void]]))
 
 (defonce metrics-registry
-         (MetricRegistry.))
+  (MetricRegistry.))
 
 (defn- merge-tags
   [additional-tags]

--- a/src/ziggurat/metrics.clj
+++ b/src/ziggurat/metrics.clj
@@ -9,16 +9,16 @@
            [io.dropwizard.metrics5 Histogram Meter MetricName MetricRegistry]
            java.util.concurrent.TimeUnit)
   (:gen-class
-   :name tech.gojek.ziggurat.internal.Metrics
-   :methods [^{:static true} [incrementCount [String String] void]
-             ^{:static true} [incrementCount [String String java.util.Map] void]
-             ^{:static true} [decrementCount [String String] void]
-             ^{:static true} [decrementCount [String String java.util.Map] void]
-             ^{:static true} [reportTime     [String long] void]
-             ^{:static true} [reportTime     [String long java.util.Map] void]]))
+    :name tech.gojek.ziggurat.internal.Metrics
+    :methods [^{:static true} [incrementCount [String String] void]
+              ^{:static true} [incrementCount [String String java.util.Map] void]
+              ^{:static true} [decrementCount [String String] void]
+              ^{:static true} [decrementCount [String String java.util.Map] void]
+              ^{:static true} [reportTime [String long] void]
+              ^{:static true} [reportTime [String long java.util.Map] void]]))
 
 (defonce metrics-registry
-  (MetricRegistry.))
+         (MetricRegistry.))
 
 (defn- merge-tags
   [additional-tags]
@@ -100,11 +100,13 @@
          histogram        ^Histogram (mk-histogram metric-namespace "all" (remove-topic-tag-for-old-namespace additional-tags metric-namespaces))] ;; verify if get-map is needed here
      (.update histogram (get-int val)))))
 
-(def report-time report-histogram)                         ;; for backward compatibility
+(def report-time report-histogram)                          ;; for backward compatibility
 
-(defn multi-ns-report-time [nss time-val additional-tags]
+(defn multi-ns-report-histogram [nss time-val additional-tags]
   (doseq [ns nss]
     (report-histogram ns time-val additional-tags)))
+
+(def multi-ns-report-time multi-ns-report-histogram)        ;; for backward compatibility
 
 (defn start-statsd-reporter [statsd-config env]
   (let [{:keys [enabled host port]} statsd-config]
@@ -114,10 +116,10 @@
                           (.withPort port)
                           (.build))
 
-            reporter (-> (DatadogReporter/forRegistry metrics-registry)
-                         (.withTransport transport)
-                         (.withTags [(str env)])
-                         (.build))]
+            reporter  (-> (DatadogReporter/forRegistry metrics-registry)
+                          (.withTransport transport)
+                          (.withTags [(str env)])
+                          (.build))]
         (log/info "Starting statsd reporter")
         (.start reporter 1 TimeUnit/SECONDS)
         {:reporter reporter :transport transport}))))

--- a/src/ziggurat/middleware/default.clj
+++ b/src/ziggurat/middleware/default.clj
@@ -24,9 +24,11 @@
       (catch Throwable e
         (let [service-name      (:app-name (ziggurat-config))
               additional-tags   {:topic_name topic-entity-name}
-              default-namespace "message-parsing"]
+              default-namespace "message-parsing"
+              metric-namespaces [service-name topic-entity-name default-namespace]
+              multi-namespaces  [metric-namespaces [default-namespace]]]
           (sentry/report-error sentry-reporter e (str "Couldn't parse the message with proto - " proto-class))
-          (metrics/increment-count default-namespace "failed" additional-tags)
+          (metrics/multi-ns-increment-count multi-namespaces "failed" additional-tags)
           nil)))
     message))
 

--- a/src/ziggurat/streams.clj
+++ b/src/ziggurat/streams.clj
@@ -110,9 +110,9 @@
   (.mapValues stream-builder (value-mapper mapper-fn)))
 
 (defn- timestamp-transformer-supplier
-  [metric-namespace oldest-processed-message-in-s additional-tags]
+  [metric-namespaces oldest-processed-message-in-s additional-tags]
   (reify TransformerSupplier
-    (get [_] (timestamp-transformer/create metric-namespace oldest-processed-message-in-s additional-tags))))
+    (get [_] (timestamp-transformer/create metric-namespaces oldest-processed-message-in-s additional-tags))))
 
 (defn- header-transformer-supplier
   []
@@ -121,9 +121,9 @@
 
 (defn- timestamp-transform-values [topic-entity-name oldest-processed-message-in-s stream-builder]
   (let [service-name     (:app-name (ziggurat-config))
-        metric-namespace "message-received-delay-histogram"
+        metric-namespaces [service-name topic-entity-name "message-received-delay-histogram"]
         additional-tags  {:topic_name topic-entity-name}]
-    (.transform stream-builder (timestamp-transformer-supplier metric-namespace oldest-processed-message-in-s additional-tags) (into-array [(.name (store-supplier-builder))]))))
+    (.transform stream-builder (timestamp-transformer-supplier metric-namespaces oldest-processed-message-in-s additional-tags) (into-array [(.name (store-supplier-builder))]))))
 
 (defn- header-transform-values [stream-builder]
   (.transformValues stream-builder (header-transformer-supplier) (into-array [(.name (store-supplier-builder))])))

--- a/src/ziggurat/streams.clj
+++ b/src/ziggurat/streams.clj
@@ -89,11 +89,14 @@
     (set-encoding-config key-deserializer-encoding value-deserializer-encoding deserializer-encoding)))
 
 (defn- log-and-report-metrics [topic-entity message]
-  (let [topic-entity-name (name topic-entity)
+  (let [service-name      (:app-name (ziggurat-config))
+        topic-entity-name (name topic-entity)
         additional-tags   {:topic_name topic-entity-name}
         default-namespace "message"
+        metric-namespaces [service-name topic-entity-name default-namespace]
+        multi-namespaces  [metric-namespaces [default-namespace]]
         metric            "read"]
-    (metrics/increment-count default-namespace metric additional-tags))
+    (metrics/multi-ns-increment-count multi-namespaces metric additional-tags))
   message)
 
 (defn store-supplier-builder []

--- a/test/ziggurat/mapper_test.clj
+++ b/test/ziggurat/mapper_test.clj
@@ -13,20 +13,22 @@
                                     fix/silence-logging]))
 
 (deftest mapper-func-test
-  (let [service-name                   (:app-name (ziggurat-config))
-        stream-routes                  {:default {:handler-fn #(constantly nil)}}
-        topic-entity                   (name (first (keys stream-routes)))
-        message-payload                {:message {:foo "bar"} :topic-entity (keyword topic-entity)}
-        expected-additional-tags       {:topic_name topic-entity}
-        expected-metric-namespace      "message-processing"
-        report-time-namespace "handler-fn-execution-time"
+  (let [service-name                    (:app-name (ziggurat-config))
+        stream-routes                   {:default {:handler-fn #(constantly nil)}}
+        topic-entity                    (name (first (keys stream-routes)))
+        message-payload                 {:message {:foo "bar"} :topic-entity (keyword topic-entity)}
+        expected-additional-tags        {:topic_name topic-entity}
+        expected-metric-namespace                "message-processing"
+        report-time-namespace           "handler-fn-execution-time"
+        expected-metric-namespaces      [topic-entity expected-metric-namespace]
         expected-report-time-namespaces [topic-entity report-time-namespace]]
     (testing "message process should be successful"
       (let [successfully-processed?     (atom false)
             successfully-reported-time? (atom false)
             expected-metric             "success"]
-        (with-redefs [metrics/increment-count (fn [metric-namespace metric additional-tags]
-                                                (when (and (= metric-namespace expected-metric-namespace)
+        (with-redefs [metrics/increment-count (fn [metric-namespaces metric additional-tags]
+                                                (when (and (or (= metric-namespaces expected-metric-namespaces)
+                                                               (= metric-namespaces [expected-metric-namespace]))
                                                            (= metric expected-metric)
                                                            (= additional-tags expected-additional-tags))
                                                   (reset! successfully-processed? true)))
@@ -43,7 +45,8 @@
         (let [successfully-processed? (atom false)
               expected-metric         "success"]
           (with-redefs [metrics/increment-count (fn [metric-namespace metric additional-tags]
-                                                  (when (and (= metric-namespace expected-metric-namespace)
+                                                  (when (and (or (= metric-namespace [service-name topic-entity expected-metric-namespace])
+                                                                 (= metric-namespace [expected-metric-namespace]))
                                                              (= metric expected-metric)
                                                              (= additional-tags expected-additional-tags))
                                                     (reset! successfully-processed? true)))]
@@ -70,7 +73,8 @@
               expected-metric           "retry"]
 
           (with-redefs [metrics/increment-count (fn [metric-namespace metric additional-tags]
-                                                  (when (and (= metric-namespace expected-metric-namespace)
+                                                  (when (and (or (= metric-namespace [service-name topic-entity expected-metric-namespace])
+                                                                 (= metric-namespace [expected-metric-namespace]))
                                                              (= metric expected-metric)
                                                              (= additional-tags expected-additional-tags))
                                                     (reset! unsuccessfully-processed? true)))]
@@ -87,7 +91,8 @@
               expected-metric           "failure"]
           (with-redefs [sentry-report           (fn [_ _ _ & _] (reset! sentry-report-fn-called? true))
                         metrics/increment-count (fn [metric-namespace metric additional-tags]
-                                                  (when (and (= metric-namespace expected-metric-namespace)
+                                                  (when (and (or (= metric-namespace [service-name topic-entity expected-metric-namespace])
+                                                                 (= metric-namespace [expected-metric-namespace]))
                                                              (= metric expected-metric)
                                                              (= additional-tags expected-additional-tags))
                                                     (reset! unsuccessfully-processed? true)))]
@@ -120,12 +125,14 @@
                                     :topic-entity topic}
         expected-topic-entity-name (name topic)
         expected-additional-tags   {:topic_name expected-topic-entity-name :channel_name channel-name}
-        expected-metric-namespace  "message-processing"]
+        increment-count-namespace  "message-processing"
+        expected-increment-count-namespaces [service-name topic channel-name increment-count-namespace]]
     (testing "message process should be successful"
       (let [successfully-processed? (atom false)
             expected-metric         "success"]
         (with-redefs [metrics/increment-count (fn [metric-namespace metric additional-tags]
-                                                (when (and (= metric-namespace expected-metric-namespace)
+                                                (when (and (or (= metric-namespace expected-increment-count-namespaces)
+                                                               (= metric-namespace [increment-count-namespace]))
                                                            (= metric expected-metric)
                                                            (= additional-tags expected-additional-tags))
                                                   (reset! successfully-processed? true)))]
@@ -139,7 +146,8 @@
               expected-metric           "retry"]
 
           (with-redefs [metrics/increment-count (fn [metric-namespace metric additional-tags]
-                                                  (when (and (= metric-namespace expected-metric-namespace)
+                                                  (when (and (or (= metric-namespace expected-increment-count-namespaces)
+                                                                 (= metric-namespace [increment-count-namespace]))
                                                              (= metric expected-metric)
                                                              (= additional-tags expected-additional-tags))
                                                     (reset! unsuccessfully-processed? true)))]
@@ -156,7 +164,8 @@
               expected-metric           "failure"]
           (with-redefs [sentry-report           (fn [_ _ _ & _] (reset! sentry-report-fn-called? true))
                         metrics/increment-count (fn [metric-namespace metric additional-tags]
-                                                  (when (and (= metric-namespace expected-metric-namespace)
+                                                  (when (and (or (= metric-namespace expected-increment-count-namespaces)
+                                                                 (= metric-namespace [increment-count-namespace]))
                                                              (= metric expected-metric)
                                                              (= additional-tags expected-additional-tags))
                                                     (reset! unsuccessfully-processed? true)))]

--- a/test/ziggurat/mapper_test.clj
+++ b/test/ziggurat/mapper_test.clj
@@ -178,12 +178,12 @@
       (let [reported-execution-time? (atom false)
             execution-time-namespace "execution-time"
             expected-execution-time-namespaces [service-name expected-topic-entity-name channel-name execution-time-namespace]]
-            (with-redefs [metrics/report-histogram (fn [metric-namespaces _ _]
-                                                     (when (or (= metric-namespaces expected-execution-time-namespaces)
-                                                               (= metric-namespaces [execution-time-namespace]))
-                                                       (reset! reported-execution-time? true)))]
-              ((channel-mapper-func (constantly :success) channel) message-payload)
-              (is @reported-execution-time?))))))
+        (with-redefs [metrics/report-histogram (fn [metric-namespaces _ _]
+                                                 (when (or (= metric-namespaces expected-execution-time-namespaces)
+                                                           (= metric-namespaces [execution-time-namespace]))
+                                                   (reset! reported-execution-time? true)))]
+          ((channel-mapper-func (constantly :success) channel) message-payload)
+          (is @reported-execution-time?))))))
 
 (deftest message-payload-schema-test
   (testing "it validates the schema for a message containing retry-count"

--- a/test/ziggurat/mapper_test.clj
+++ b/test/ziggurat/mapper_test.clj
@@ -50,20 +50,6 @@
               (is (= message-payload message-from-mq))
               (is @successfully-processed?))))))
 
-    (testing "message process should successfully push to delay channel queue"
-      (fix/with-queues (assoc-in stream-routes [:default :channel-delay] (constantly :success))
-        (let [successfully-processed? (atom false)
-              expected-metric         "success"]
-          (with-redefs [metrics/increment-count (fn [metric-namespaces metric additional-tags]
-                                                  (when (and (= metric-namespaces expected-metric-namespace)
-                                                             (= metric expected-metric)
-                                                             (= additional-tags expected-additional-tags))
-                                                    (reset! successfully-processed? true)))]
-            ((mapper-func (constantly :channel-delay) [:channel-delay]) message-payload)
-            (let [message-from-mq (rmq/get-message-from-channel-delay-queue :default :channel-delay)]
-              (is (= message-payload message-from-mq))
-              (is @successfully-processed?))))))
-
     (testing "message process should raise exception if channel not in list"
       (fix/with-queues
         (assoc-in stream-routes [:default :channel-1] (constantly :success))

--- a/test/ziggurat/metrics_test.clj
+++ b/test/ziggurat/metrics_test.clj
@@ -50,18 +50,18 @@
         input-additional-tags      {:topic_name expected-topic-entity-name}
         expected-n                 1]
     (testing "increases count on the meter - vector as an argument"
-      (let [expected-metric-namespace ["metric" "ns"]
+      (let [expected-metric-namespaces [expected-topic-entity-name "metric-ns"]
             mk-meter-args             (atom nil)
             meter                     (Meter.)
-            expected-additional-tags  input-additional-tags]
-        (with-redefs [metrics/mk-meter (fn [metric-namespace metric additional-tags]
+            expected-additional-tags  {}]
+        (with-redefs [metrics/mk-meter (fn [metric-namespaces metric additional-tags]
                                          (is (= additional-tags expected-additional-tags))
-                                         (reset! mk-meter-args {:metric-namespace metric-namespace
+                                         (reset! mk-meter-args {:metric-namespaces metric-namespaces
                                                                 :metric           metric})
                                          meter)]
-          (metrics/increment-count expected-metric-namespace metric expected-n input-additional-tags)
+          (metrics/increment-count expected-metric-namespaces metric expected-n input-additional-tags)
           (is (= expected-n (.getCount meter)))
-          (is (= (metrics/intercalate-dot expected-metric-namespace) (:metric-namespace @mk-meter-args)))
+          (is (= (metrics/intercalate-dot expected-metric-namespaces) (:metric-namespaces @mk-meter-args)))
           (is (= metric (:metric @mk-meter-args))))))
     (testing "increases count on the meter - 3rd argument is a number"
       (let [expected-metric-namespace ["metric" "ns"]
@@ -103,21 +103,21 @@
                                          meter)]
           (metrics/increment-count expected-metric-namespaces metric expected-n input-additional-tags)
           (is (= expected-n (.getCount meter)))
-          (is (= expected-metric-namespaces (:metric-namespaces @mk-meter-args)))
+          (is (= (str (:app-name (ziggurat-config)) "." expected-metric-namespaces) (:metric-namespaces @mk-meter-args)))
           (is (= metric (:metric @mk-meter-args))))))
     (testing "increases count on the meter - w/o additional-tags argument"
-      (let [expected-metric-namespace "metric-ns"
+      (let [expected-metric-namespaces [expected-topic-entity-name "metric-ns"]
             mk-meter-args             (atom nil)
             meter                     (Meter.)
             expected-additional-tags  {}]
-        (with-redefs [metrics/mk-meter (fn [metric-namespace metric additional-tags]
+        (with-redefs [metrics/mk-meter (fn [metric-namespaces metric additional-tags]
                                          (is (= additional-tags expected-additional-tags))
-                                         (reset! mk-meter-args {:metric-namespace metric-namespace
+                                         (reset! mk-meter-args {:metric-namespace metric-namespaces
                                                                 :metric           metric})
                                          meter)]
-          (metrics/increment-count expected-metric-namespace metric)
+          (metrics/increment-count expected-metric-namespaces metric)
           (is (= expected-n (.getCount meter)))
-          (is (= expected-metric-namespace (:metric-namespace @mk-meter-args)))
+          (is (= (metrics/intercalate-dot expected-metric-namespaces) (:metric-namespace @mk-meter-args)))
           (is (= metric (:metric @mk-meter-args))))))
     (testing "increases count on the meter when additional-tags is nil"
       (let [expected-metric-namespace "metric-ns"
@@ -129,9 +129,9 @@
                                          (reset! mk-meter-args {:metric-namespace metric-namespace
                                                                 :metric           metric})
                                          meter)]
-          (metrics/increment-count expected-metric-namespace metric expected-n expected-additional-tags)
+          (metrics/increment-count expected-metric-namespace metric expected-n nil)
           (is (= expected-n (.getCount meter)))
-          (is (= expected-metric-namespace (:metric-namespace @mk-meter-args)))
+          (is (= (str (:app-name (ziggurat-config)) "." expected-metric-namespace) (:metric-namespace @mk-meter-args)))
           (is (= metric (:metric @mk-meter-args))))))
     (testing "-incrementCount calls increment-count with the correct arguments"
       (let [metric-namespace "namespace"
@@ -165,18 +165,18 @@
         input-additional-tags {:topic_name expected-topic-name}
         expected-n            1]
     (testing "decreases count on the meter - vector as an argument"
-      (let [expected-additional-tags  input-additional-tags
-            expected-metric-namespace ["metric" "ns"]]
-        (with-redefs [metrics/mk-meter (fn [metric-namespace metric additional-tags]
+      (let [expected-additional-tags  {}
+            expected-metric-namespaces [expected-topic-name "metric-ns"]]
+        (with-redefs [metrics/mk-meter (fn [metric-namespaces metric additional-tags]
                                          (is (= additional-tags expected-additional-tags))
-                                         (reset! mk-meter-args {:metric-namespace metric-namespace
+                                         (reset! mk-meter-args {:metric-namespaces metric-namespaces
                                                                 :metric           metric})
                                          meter)]
-          (metrics/increment-count expected-metric-namespace metric expected-n input-additional-tags)
+          (metrics/increment-count expected-metric-namespaces metric expected-n input-additional-tags)
           (is (= expected-n (.getCount meter)))
-          (metrics/decrement-count expected-metric-namespace metric expected-n input-additional-tags)
+          (metrics/decrement-count expected-metric-namespaces metric expected-n input-additional-tags)
           (is (zero? (.getCount meter)))
-          (is (= (metrics/intercalate-dot expected-metric-namespace) (:metric-namespace @mk-meter-args)))
+          (is (= (metrics/intercalate-dot expected-metric-namespaces) (:metric-namespaces @mk-meter-args)))
           (is (= metric (:metric @mk-meter-args))))))
     (testing "decreases count on the meter - string as an argument"
       (let [expected-additional-tags   input-additional-tags
@@ -190,7 +190,7 @@
           (is (= expected-n (.getCount meter)))
           (metrics/decrement-count expected-metric-namespaces metric expected-n input-additional-tags)
           (is (zero? (.getCount meter)))
-          (is (= expected-metric-namespaces (:metric-namespaces @mk-meter-args)))
+          (is (= (str (:app-name (ziggurat-config)) "." expected-metric-namespaces) (:metric-namespaces @mk-meter-args)))
           (is (= metric (:metric @mk-meter-args))))))
     (testing "decreases count on the meter - without topic name on the namespace"
       (let [expected-additional-tags   input-additional-tags
@@ -214,11 +214,11 @@
                                          (reset! mk-meter-args {:metric-namespace metric-namespace
                                                                 :metric           metric})
                                          meter)]
-          (metrics/increment-count expected-metric-namespace metric expected-n expected-additional-tags)
+          (metrics/increment-count expected-metric-namespace metric expected-n nil)
           (is (= expected-n (.getCount meter)))
-          (metrics/decrement-count expected-metric-namespace metric expected-n expected-additional-tags)
+          (metrics/decrement-count expected-metric-namespace metric expected-n nil)
           (is (zero? (.getCount meter)))
-          (is (= expected-metric-namespace (:metric-namespace @mk-meter-args)))
+          (is (= (str (:app-name (ziggurat-config)) "." expected-metric-namespace) (:metric-namespace @mk-meter-args)))
           (is (= metric (:metric @mk-meter-args))))))
     (testing "-decrementCount passes the correct arguments to decrement-count"
       (let [metric-namespace "namespace"
@@ -249,11 +249,11 @@
         input-additional-tags      {:topic_name expected-topic-entity-name}
         time-val                   10]
     (testing "updates time-val - vector as an argument"
-      (let [expected-metric-namespace ["message-received-delay-histogram" "ns"]
+      (let [expected-metric-namespace [expected-topic-entity-name "message-received-delay-histogram"]
             mk-histogram-args         (atom nil)
             reservoir                 (UniformReservoir.)
             histogram                 (Histogram. reservoir)
-            expected-additional-tags  input-additional-tags]
+            expected-additional-tags  {}]
         (with-redefs [metrics/mk-histogram (fn [metric-namespace metric additional-tags]
                                              (is (= additional-tags expected-additional-tags))
                                              (reset! mk-histogram-args {:metric-namespace metric-namespace
@@ -276,7 +276,7 @@
                                              histogram)]
           (metrics/report-histogram expected-metric-namespaces time-val input-additional-tags)
           (is (= 1 (.getCount histogram)))
-          (is (= expected-metric-namespaces (:metric-namespaces @mk-histogram-args)))
+          (is (= (str (:app-name (ziggurat-config)) "." expected-metric-namespaces) (:metric-namespaces @mk-histogram-args)))
           (is (= "all" (:metric @mk-histogram-args))))))
     (testing "updates time-val - w/o additional-tags argument"
       (let [expected-metric-namespace "message-received-delay-histogram"
@@ -291,7 +291,7 @@
                                              histogram)]
           (metrics/report-histogram expected-metric-namespace time-val)
           (is (= 1 (.getCount histogram)))
-          (is (= expected-metric-namespace (:metric-namespace @mk-histogram-args)))
+          (is (= (str (:app-name (ziggurat-config)) "." expected-metric-namespace) (:metric-namespace @mk-histogram-args)))
           (is (= "all" (:metric @mk-histogram-args)))))))
   (testing "report time java function passes the correct parameters to report time"
     (let [expected-metric-namespace "namespace"

--- a/test/ziggurat/middleware/default_test.clj
+++ b/test/ziggurat/middleware/default_test.clj
@@ -30,7 +30,7 @@
           handler-fn              (fn [msg]
                                     (if (nil? msg)
                                       (reset! handler-fn-called? true)))]
-      (with-redefs [metrics/increment-count (fn [_ _ _]
+      (with-redefs [metrics/multi-ns-increment-count (fn [_ _ _]
                                               (reset! metric-reporter-called? true))]
         ((protobuf->hash handler-fn nil topic-entity-name) nil))
       (is (true? @handler-fn-called?))

--- a/test/ziggurat/middleware/default_test.clj
+++ b/test/ziggurat/middleware/default_test.clj
@@ -31,7 +31,7 @@
                                     (if (nil? msg)
                                       (reset! handler-fn-called? true)))]
       (with-redefs [metrics/multi-ns-increment-count (fn [_ _ _]
-                                              (reset! metric-reporter-called? true))]
+                                                       (reset! metric-reporter-called? true))]
         ((protobuf->hash handler-fn nil topic-entity-name) nil))
       (is (true? @handler-fn-called?))
       (is (true? @metric-reporter-called?))))

--- a/test/ziggurat/middleware/json_test.clj
+++ b/test/ziggurat/middleware/json_test.clj
@@ -53,7 +53,7 @@
                                     (if (nil? msg)
                                       (reset! handler-fn-called? true)))]
       (with-redefs [metrics/multi-ns-increment-count (fn [_ _ _]
-                                              (reset! metric-reporter-called? true))]
+                                                       (reset! metric-reporter-called? true))]
         ((parse-json handler-fn topic-entity-name true) message))
       (is (true? @handler-fn-called?))
       (is (true? @metric-reporter-called?)))))

--- a/test/ziggurat/middleware/json_test.clj
+++ b/test/ziggurat/middleware/json_test.clj
@@ -52,7 +52,7 @@
           handler-fn              (fn [msg]
                                     (if (nil? msg)
                                       (reset! handler-fn-called? true)))]
-      (with-redefs [metrics/increment-count (fn [_ _ _]
+      (with-redefs [metrics/multi-ns-increment-count (fn [_ _ _]
                                               (reset! metric-reporter-called? true))]
         ((parse-json handler-fn topic-entity-name true) message))
       (is (true? @handler-fn-called?))


### PR DESCRIPTION
Reintroduces the older format of metrics.
Now Ziggurat will produce metrics in both the Prometheus like format and the old influx format.

This PR fixes the breaking change of metrics format that was introduced in 3.0.0.