### PR TITLE
publishes custom metric-namespaces as actor_prefixed and original

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to this project will be documented in this file. This change
 
 ## Unreleased Changes
 
+## 3.1.0-alpha.5 - 2019-12-5
+- Fixes metrics publishing for custom metrics (i.e. string metric namespaces): In 2.x ziggurat appended the service_name
+  to a string metrics namespace (e.g. "metric" -> "service_name.metric"), we changed the contract in 3.0 by
+  removing the service_name from the metric name and instead adding a tag for it. To have backward compatibility with both
+  2.x and 3.0 we now send metrics in both formats
+
 ## 3.1.0-alpha.4 - 2019-12-4
 - Reintroduces old metrics format (statsd). Ziggurat now pushes metrics in both formats (statsd and prometheus like).
 - Reverts the changes for exponential backoff, the current implementation was broken and a new PR is being raised with the correct approach.

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject tech.gojek/ziggurat "3.1.0-alpha.4"
+(defproject tech.gojek/ziggurat "3.1.0-alpha.5"
   :description "A stream processing framework to build stateless applications on kafka"
   :url "https://github.com/gojektech/ziggurat"
   :license {:name "Apache License, Version 2.0"


### PR DESCRIPTION
- To keep backward compatibility we added actor_name as a prefix in
custom metrics (i.e. string namespaces). This breaks backward
compatibility with 3.0.0 where the string namespaces were published as
is. So this commit addresses the issue by publishing string namespaces
as both prefixed and original