### PR TITLE
[WIP] Ack-ing a RabbitMQ message after processing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file. This change
 
 ## Unreleased Changes
 
+## 3.2.0-alpha.2 - 2019-12-12
+- Fixes [this bug](https://github.com/gojek/ziggurat/issues/115) in RabbitMQ message processing flow
+
 ## 3.2.0-alpha.1 - 2019-12-12
 - Adds support for exponential backoffs in channels and normal retry flow
 - exponential backoffs can be enabled from the config

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject tech.gojek/ziggurat "3.2.0-alpha.1"
+(defproject tech.gojek/ziggurat "3.2.0-alpha.2"
   :description "A stream processing framework to build stateless applications on kafka"
   :url "https://github.com/gojektech/ziggurat"
   :license {:name "Apache License, Version 2.0"

--- a/src/ziggurat/messaging/consumer.clj
+++ b/src/ziggurat/messaging/consumer.clj
@@ -91,7 +91,7 @@
 
    For example, this method can be used to delete messages from dead-letter queue if `ack?` is set to true."
   ([ack? topic-entity count]
-    (get-dead-set-messages ack? topic-entity nil count))
+   (get-dead-set-messages ack? topic-entity nil count))
   ([ack? topic-entity channel count]
    (remove nil?
            (with-open [ch (lch/open connection)]
@@ -104,12 +104,12 @@
   ([topic-entity count processing-fn]
    (process-dead-set-messages topic-entity nil count processing-fn))
   ([topic-entity channel count processing-fn]
-    (with-open [ch (lch/open connection)]
-      (doall (for [_ (range count)]
-               (let [queue-name     (construct-queue-name topic-entity channel)
-                     [meta payload] (lb/get ch queue-name false)]
-                 (when (some? payload)
-                   (process-message ch meta payload topic-entity processing-fn))))))))
+   (with-open [ch (lch/open connection)]
+     (doall (for [_ (range count)]
+              (let [queue-name     (construct-queue-name topic-entity channel)
+                    [meta payload] (lb/get ch queue-name false)]
+                (when (some? payload)
+                  (process-message ch meta payload topic-entity processing-fn))))))))
 
 (defn- message-handler [wrapped-mapper-fn topic-entity]
   (fn [ch meta ^bytes payload]

--- a/src/ziggurat/messaging/consumer.clj
+++ b/src/ziggurat/messaging/consumer.clj
@@ -101,11 +101,17 @@
      (prefixed-queue-name topic-entity (get-in-config [:rabbit-mq :dead-letter :queue-name]))
      (prefixed-channel-name topic-entity channel (get-in-config [:rabbit-mq :dead-letter :queue-name])))))
 
-(defn get-dead-set-messages-for-topic [ack? topic-entity count]
-  (get-dead-set-messages* ack?
-                          (construct-queue-name topic-entity)
-                          count
-                          topic-entity))
+(defn get-dead-set-messages
+  ([ack? topic-entity count]
+    (get-dead-set-messages* ack?
+                            (construct-queue-name topic-entity)
+                            count
+                            topic-entity))
+  ([ack? topic-entity channel count]
+   (get-dead-set-messages* ack?
+                           (construct-queue-name topic-entity channel)
+                           count
+                           topic-entity)))
 
 (defn get-dead-set-messages-for-channel [ack? topic-entity channel count]
   (get-dead-set-messages* ack?

--- a/src/ziggurat/messaging/consumer.clj
+++ b/src/ziggurat/messaging/consumer.clj
@@ -103,21 +103,12 @@
 
 (defn get-dead-set-messages
   ([ack? topic-entity count]
-    (get-dead-set-messages* ack?
-                            (construct-queue-name topic-entity)
-                            count
-                            topic-entity))
+    (get-dead-set-messages ack? topic-entity nil count))
   ([ack? topic-entity channel count]
    (get-dead-set-messages* ack?
                            (construct-queue-name topic-entity channel)
                            count
                            topic-entity)))
-
-(defn get-dead-set-messages-for-channel [ack? topic-entity channel count]
-  (get-dead-set-messages* ack?
-                          (construct-queue-name topic-entity channel)
-                          count
-                          topic-entity))
 
 (defn- message-handler [wrapped-mapper-fn topic-entity]
   (fn [ch meta ^bytes payload]

--- a/src/ziggurat/messaging/consumer.clj
+++ b/src/ziggurat/messaging/consumer.clj
@@ -93,16 +93,23 @@
             (doall (for [_ (range count)]
                      (try-consuming-dead-set-messages ch ack? queue-name topic-entity))))))
 
+(defn- construct-queue-name
+  ([topic-entity]
+   (construct-queue-name topic-entity nil))
+  ([topic-entity channel]
+   (if (nil? channel)
+     (prefixed-queue-name topic-entity (get-in-config [:rabbit-mq :dead-letter :queue-name]))
+     (prefixed-channel-name topic-entity channel (get-in-config [:rabbit-mq :dead-letter :queue-name])))))
+
 (defn get-dead-set-messages-for-topic [ack? topic-entity count]
   (get-dead-set-messages* ack?
-                          (prefixed-queue-name topic-entity
-                                               (get-in-config [:rabbit-mq :dead-letter :queue-name]))
+                          (construct-queue-name topic-entity)
                           count
                           topic-entity))
 
 (defn get-dead-set-messages-for-channel [ack? topic-entity channel count]
   (get-dead-set-messages* ack?
-                          (prefixed-channel-name topic-entity channel (get-in-config [:rabbit-mq :dead-letter :queue-name]))
+                          (construct-queue-name topic-entity channel)
                           count
                           topic-entity))
 

--- a/src/ziggurat/messaging/consumer.clj
+++ b/src/ziggurat/messaging/consumer.clj
@@ -42,7 +42,7 @@
 
 (defn- ack-message
   [ch delivery-tag]
-    (lb/ack ch delivery-tag))
+  (lb/ack ch delivery-tag))
 
 (defn process-message-from-queue [ch meta payload topic-entity processing-fn]
   (let [delivery-tag (:delivery-tag meta)

--- a/src/ziggurat/messaging/dead_set.clj
+++ b/src/ziggurat/messaging/dead_set.clj
@@ -1,10 +1,12 @@
 (ns ziggurat.messaging.dead-set
   (:require [ziggurat.messaging.consumer :as consumer]
-            [ziggurat.messaging.producer :as producer]))
+            [ziggurat.messaging.producer :as producer]
+            [clojure.tools.logging :as log]))
 
 (defn replay
   "Gets the message from the queue and puts them to instant queue"
   [count-of-message topic-entity channel]
+  (log/debugf "Replaying %d number of messages from dead-letter-queue for topic [%s] and channel [%s]", count-of-message, topic-entity, channel)
   (if (nil? channel)
     (consumer/process-dead-set-messages topic-entity count-of-message
                                         (fn [message-payload]
@@ -16,10 +18,12 @@
 (defn view
   "Gets n number of messages from dead queue"
   [count-of-message topic-entity channel]
-  (consumer/get-dead-set-messages false topic-entity channel count-of-message))
+  (log/debugf "Getting %d number of messages from dead-letter-queue for topic [%s] and channel [%s]", count-of-message, topic-entity, channel)
+  (consumer/get-dead-set-messages topic-entity channel count-of-message))
 
 (defn delete
   "Deletes n number of messages from dead queue"
   [count-of-message topic-entity channel]
-  (consumer/get-dead-set-messages true topic-entity channel count-of-message))
+  (log/debugf "Deleting %d number of messages from dead-letter-queue for topic [%s] and channel [%s]", count-of-message, topic-entity, channel)
+  (consumer/process-dead-set-messages topic-entity channel count-of-message (fn [message-payload])))
 

--- a/src/ziggurat/messaging/dead_set.clj
+++ b/src/ziggurat/messaging/dead_set.clj
@@ -8,23 +8,16 @@
   (if (nil? channel)
     (doseq [message-payload (consumer/get-dead-set-messages true topic-entity count-of-message)]
       (producer/publish-to-instant-queue message-payload))
-    (doseq [message-payload (consumer/get-dead-set-messages-for-channel true topic-entity channel count-of-message)]
+    (doseq [message-payload (consumer/get-dead-set-messages true topic-entity channel count-of-message)]
       (producer/publish-to-channel-instant-queue channel message-payload))))
-
-(defn- get-messages
-  "Gets n messages from dead queue and gives the option to ack or un-ack them"
-  [count-of-message topic-entity channel ack?]
-  (if (nil? channel)
-    (consumer/get-dead-set-messages ack? topic-entity count-of-message)
-    (consumer/get-dead-set-messages-for-channel ack? topic-entity channel count-of-message)))
 
 (defn view
   "Gets n number of messages from dead queue"
   [count-of-message topic-entity channel]
-  (get-messages count-of-message topic-entity channel false))
+  (consumer/get-dead-set-messages false topic-entity channel count-of-message))
 
 (defn delete
   "Deletes n number of messages from dead queue"
   [count-of-message topic-entity channel]
-  (get-messages count-of-message topic-entity channel true))
+  (consumer/get-dead-set-messages true topic-entity channel count-of-message))
 

--- a/src/ziggurat/messaging/dead_set.clj
+++ b/src/ziggurat/messaging/dead_set.clj
@@ -6,10 +6,12 @@
   "Gets the message from the queue and puts them to instant queue"
   [count-of-message topic-entity channel]
   (if (nil? channel)
-    (doseq [message-payload (consumer/get-dead-set-messages true topic-entity count-of-message)]
-      (producer/publish-to-instant-queue message-payload))
-    (doseq [message-payload (consumer/get-dead-set-messages true topic-entity channel count-of-message)]
-      (producer/publish-to-channel-instant-queue channel message-payload))))
+    (consumer/process-dead-set-messages topic-entity count-of-message
+                                      (fn [message-payload]
+                                        (producer/publish-to-instant-queue message-payload)))
+    (consumer/process-dead-set-messages topic-entity channel count-of-message
+                                        (fn [message-payload]
+                                          (producer/publish-to-channel-instant-queue channel message-payload)))))
 
 (defn view
   "Gets n number of messages from dead queue"

--- a/src/ziggurat/messaging/dead_set.clj
+++ b/src/ziggurat/messaging/dead_set.clj
@@ -6,7 +6,7 @@
   "Gets the message from the queue and puts them to instant queue"
   [count-of-message topic-entity channel]
   (if (nil? channel)
-    (doseq [message-payload (consumer/get-dead-set-messages-for-topic true topic-entity count-of-message)]
+    (doseq [message-payload (consumer/get-dead-set-messages true topic-entity count-of-message)]
       (producer/publish-to-instant-queue message-payload))
     (doseq [message-payload (consumer/get-dead-set-messages-for-channel true topic-entity channel count-of-message)]
       (producer/publish-to-channel-instant-queue channel message-payload))))
@@ -15,7 +15,7 @@
   "Gets n messages from dead queue and gives the option to ack or un-ack them"
   [count-of-message topic-entity channel ack?]
   (if (nil? channel)
-    (consumer/get-dead-set-messages-for-topic ack? topic-entity count-of-message)
+    (consumer/get-dead-set-messages ack? topic-entity count-of-message)
     (consumer/get-dead-set-messages-for-channel ack? topic-entity channel count-of-message)))
 
 (defn view

--- a/src/ziggurat/messaging/dead_set.clj
+++ b/src/ziggurat/messaging/dead_set.clj
@@ -7,8 +7,8 @@
   [count-of-message topic-entity channel]
   (if (nil? channel)
     (consumer/process-dead-set-messages topic-entity count-of-message
-                                      (fn [message-payload]
-                                        (producer/publish-to-instant-queue message-payload)))
+                                        (fn [message-payload]
+                                          (producer/publish-to-instant-queue message-payload)))
     (consumer/process-dead-set-messages topic-entity channel count-of-message
                                         (fn [message-payload]
                                           (producer/publish-to-channel-instant-queue channel message-payload)))))

--- a/test/ziggurat/messaging/consumer_test.clj
+++ b/test/ziggurat/messaging/consumer_test.clj
@@ -24,30 +24,30 @@
   (let [message-payload   (assoc (gen-message-payload topic-entity) :retry-count 0)]
     (testing "it maps the process-message-from-queue over all the messages fetched from the queue for a topic"
       (fix/with-queues {topic-entity {:handler-fn (constantly nil)}}
-         (let [count             5
-               process-fn-called (atom 0)
-               processing-fn     (fn [message]
-                                   (when (= message message-payload)
-                                     (swap! process-fn-called inc)))
-               _                 (doseq [_ (range count)]
-                                   (producer/publish-to-dead-queue message-payload))]
-             (consumer/process-dead-set-messages topic-entity count processing-fn)
-             (is (= count @process-fn-called))
-             (is (empty? (get-dead-set-messages topic-entity count))))))
+        (let [count             5
+              process-fn-called (atom 0)
+              processing-fn     (fn [message]
+                                  (when (= message message-payload)
+                                    (swap! process-fn-called inc)))
+              _                 (doseq [_ (range count)]
+                                  (producer/publish-to-dead-queue message-payload))]
+          (consumer/process-dead-set-messages topic-entity count processing-fn)
+          (is (= count @process-fn-called))
+          (is (empty? (get-dead-set-messages topic-entity count))))))
     (testing "it maps the process-message-from-queue over all the messages fetched from the queue for a channel"
       (fix/with-queues {topic-entity {:handler-fn (constantly nil)
                                       :channel-1  (constantly nil)}}
-         (let [count             5
-               channel           "channel-1"
-               process-fn-called (atom 0)
-               processing-fn     (fn [message]
-                                   (when (= message message-payload)
-                                     (swap! process-fn-called inc)))
-               _                 (doseq [_ (range count)]
-                                   (producer/publish-to-channel-dead-queue channel message-payload))]
-             (consumer/process-dead-set-messages topic-entity channel count processing-fn)
-             (is (= count @process-fn-called))
-             (is (empty? (get-dead-set-messages topic-entity channel count))))))))
+        (let [count             5
+              channel           "channel-1"
+              process-fn-called (atom 0)
+              processing-fn     (fn [message]
+                                  (when (= message message-payload)
+                                    (swap! process-fn-called inc)))
+              _                 (doseq [_ (range count)]
+                                  (producer/publish-to-channel-dead-queue channel message-payload))]
+          (consumer/process-dead-set-messages topic-entity channel count processing-fn)
+          (is (= count @process-fn-called))
+          (is (empty? (get-dead-set-messages topic-entity channel count))))))))
 
 (deftest get-dead-set-messages-test
   (let [message-payload   (assoc (gen-message-payload topic-entity) :retry-count 0)]

--- a/test/ziggurat/messaging/consumer_test.clj
+++ b/test/ziggurat/messaging/consumer_test.clj
@@ -23,43 +23,43 @@
   (let [message-payload   (assoc (gen-message-payload topic-entity) :retry-count 0)]
     (testing "when ack is enabled, get the dead set messages and remove from dead set"
       (fix/with-queues {topic-entity {:handler-fn (constantly nil)}}
-                       (let [count-of-messages 10
+        (let [count-of-messages 10
               pushed-message    (doseq [_ (range count-of-messages)]
                                   (producer/publish-to-dead-queue message-payload))
               dead-set-messages (get-dead-set-messages true topic-entity count-of-messages)]
-                         (is (= (repeat count-of-messages message-payload) dead-set-messages))
-                         (is (empty? (get-dead-set-messages true topic-entity count-of-messages))))))
+          (is (= (repeat count-of-messages message-payload) dead-set-messages))
+          (is (empty? (get-dead-set-messages true topic-entity count-of-messages))))))
 
     (testing "when ack is disabled, get the dead set messages and not remove from dead set"
       (fix/with-queues {topic-entity {:handler-fn (constantly nil)}}
-                       (let [count-of-messages 10
+        (let [count-of-messages 10
               pushed-message    (doseq [_ (range count-of-messages)]
                                   (producer/publish-to-dead-queue message-payload))
               dead-set-messages (get-dead-set-messages false topic-entity count-of-messages)]
-                         (is (= (repeat count-of-messages message-payload) dead-set-messages))
-                         (is (= (repeat count-of-messages message-payload) (get-dead-set-messages false topic-entity count-of-messages))))))))
+          (is (= (repeat count-of-messages message-payload) dead-set-messages))
+          (is (= (repeat count-of-messages message-payload) (get-dead-set-messages false topic-entity count-of-messages))))))))
 
 (deftest get-dead-set-messages-from-channel-test
   (let [message-payload (assoc (gen-message-payload topic-entity) :retry-count 0)]
     (testing "when ack is enabled, get the dead set messages and remove from dead set"
       (fix/with-queues {topic-entity {:handler-fn (constantly nil)
                                       :channel-1  (constantly nil)}}
-                       (let [count-of-messages 10
+        (let [count-of-messages 10
               channel           "channel-1"
               pushed-message    (doseq [_ (range count-of-messages)]
                                   (producer/publish-to-channel-dead-queue channel message-payload))
               dead-set-messages (get-dead-set-messages true topic-entity channel count-of-messages)]
-                         (is (= (repeat count-of-messages message-payload) dead-set-messages))
-                         (is (empty? (get-dead-set-messages true topic-entity channel count-of-messages))))))
+          (is (= (repeat count-of-messages message-payload) dead-set-messages))
+          (is (empty? (get-dead-set-messages true topic-entity channel count-of-messages))))))
 
     (testing "when ack is disabled, get the dead set messages and not remove from dead set"
       (fix/with-queues {topic-entity {:handler-fn #(constantly nil)}}
-                       (let [count-of-messages 10
+        (let [count-of-messages 10
               pushed-message    (doseq [_ (range count-of-messages)]
                                   (producer/publish-to-dead-queue message-payload))
               dead-set-messages (get-dead-set-messages false topic-entity count-of-messages)]
-                         (is (= (repeat count-of-messages message-payload) dead-set-messages))
-                         (is (= (repeat count-of-messages message-payload) (get-dead-set-messages false topic-entity count-of-messages))))))))
+          (is (= (repeat count-of-messages message-payload) dead-set-messages))
+          (is (= (repeat count-of-messages message-payload) (get-dead-set-messages false topic-entity count-of-messages))))))))
 
 (defn- mock-mapper-fn [{:keys [retry-counter-atom
                                call-counter-atom

--- a/test/ziggurat/messaging/consumer_test.clj
+++ b/test/ziggurat/messaging/consumer_test.clj
@@ -329,7 +329,7 @@
                               (reset! processing-fn-called true)))
             topic-entity-name (name topic-entity)]
         (producer/publish-to-dead-queue message)
-        (with-redefs [convert-message (fn [_ _ _ _] nil)]
+        (with-redefs [convert-and-ack-message (fn [_ _ _ _ _] nil)]
           (with-open [ch (lch/open connection)]
             (let [queue-name          (get-in (rabbitmq-config) [:dead-letter :queue-name])
                   prefixed-queue-name (str topic-entity-name "_" queue-name)

--- a/test/ziggurat/messaging/consumer_test.clj
+++ b/test/ziggurat/messaging/consumer_test.clj
@@ -23,43 +23,43 @@
   (let [message-payload   (assoc (gen-message-payload topic-entity) :retry-count 0)]
     (testing "when ack is enabled, get the dead set messages and remove from dead set"
       (fix/with-queues {topic-entity {:handler-fn (constantly nil)}}
-        (let [count-of-messages 10
+                       (let [count-of-messages 10
               pushed-message    (doseq [_ (range count-of-messages)]
                                   (producer/publish-to-dead-queue message-payload))
-              dead-set-messages (get-dead-set-messages-for-topic true topic-entity count-of-messages)]
-          (is (= (repeat count-of-messages message-payload) dead-set-messages))
-          (is (empty? (get-dead-set-messages-for-topic true topic-entity count-of-messages))))))
+              dead-set-messages (get-dead-set-messages true topic-entity count-of-messages)]
+                         (is (= (repeat count-of-messages message-payload) dead-set-messages))
+                         (is (empty? (get-dead-set-messages true topic-entity count-of-messages))))))
 
     (testing "when ack is disabled, get the dead set messages and not remove from dead set"
       (fix/with-queues {topic-entity {:handler-fn (constantly nil)}}
-        (let [count-of-messages 10
+                       (let [count-of-messages 10
               pushed-message    (doseq [_ (range count-of-messages)]
                                   (producer/publish-to-dead-queue message-payload))
-              dead-set-messages (get-dead-set-messages-for-topic false topic-entity count-of-messages)]
-          (is (= (repeat count-of-messages message-payload) dead-set-messages))
-          (is (= (repeat count-of-messages message-payload) (get-dead-set-messages-for-topic false topic-entity count-of-messages))))))))
+              dead-set-messages (get-dead-set-messages false topic-entity count-of-messages)]
+                         (is (= (repeat count-of-messages message-payload) dead-set-messages))
+                         (is (= (repeat count-of-messages message-payload) (get-dead-set-messages false topic-entity count-of-messages))))))))
 
 (deftest get-dead-set-messages-from-channel-test
   (let [message-payload (assoc (gen-message-payload topic-entity) :retry-count 0)]
     (testing "when ack is enabled, get the dead set messages and remove from dead set"
       (fix/with-queues {topic-entity {:handler-fn (constantly nil)
                                       :channel-1  (constantly nil)}}
-        (let [count-of-messages 10
+                       (let [count-of-messages 10
               channel           "channel-1"
               pushed-message    (doseq [_ (range count-of-messages)]
                                   (producer/publish-to-channel-dead-queue channel message-payload))
-              dead-set-messages (get-dead-set-messages-for-channel true topic-entity channel count-of-messages)]
-          (is (= (repeat count-of-messages message-payload) dead-set-messages))
-          (is (empty? (get-dead-set-messages-for-channel true topic-entity channel count-of-messages))))))
+              dead-set-messages (get-dead-set-messages true topic-entity channel count-of-messages)]
+                         (is (= (repeat count-of-messages message-payload) dead-set-messages))
+                         (is (empty? (get-dead-set-messages true topic-entity channel count-of-messages))))))
 
     (testing "when ack is disabled, get the dead set messages and not remove from dead set"
       (fix/with-queues {topic-entity {:handler-fn #(constantly nil)}}
-        (let [count-of-messages 10
+                       (let [count-of-messages 10
               pushed-message    (doseq [_ (range count-of-messages)]
                                   (producer/publish-to-dead-queue message-payload))
-              dead-set-messages (get-dead-set-messages-for-topic false topic-entity count-of-messages)]
-          (is (= (repeat count-of-messages message-payload) dead-set-messages))
-          (is (= (repeat count-of-messages message-payload) (get-dead-set-messages-for-topic false topic-entity count-of-messages))))))))
+              dead-set-messages (get-dead-set-messages false topic-entity count-of-messages)]
+                         (is (= (repeat count-of-messages message-payload) dead-set-messages))
+                         (is (= (repeat count-of-messages message-payload) (get-dead-set-messages false topic-entity count-of-messages))))))))
 
 (defn- mock-mapper-fn [{:keys [retry-counter-atom
                                call-counter-atom
@@ -167,13 +167,13 @@
             (producer/retry (gen-message-payload topic-entity)))
 
           (block-and-retry-until (fn []
-                                   (let [dead-set-msgs (count (get-dead-set-messages-for-topic false topic-entity no-of-msgs))]
+                                   (let [dead-set-msgs (count (get-dead-set-messages false topic-entity no-of-msgs))]
                                      (if (< dead-set-msgs no-of-msgs)
                                        (throw (ex-info "Dead set messages were never populated"
                                                        {:dead-set-msgs dead-set-msgs}))))))
 
           (is (= (* retry-count no-of-msgs) @retry-counter))
-          (is (= no-of-msgs (count (get-dead-set-messages-for-topic false topic-entity no-of-msgs)))))
+          (is (= no-of-msgs (count (get-dead-set-messages false topic-entity no-of-msgs)))))
         (util/close rmq-ch))))
 
   (testing "start subscribers should not call start-subscriber* when stream router is nil"

--- a/test/ziggurat/util/rabbitmq.clj
+++ b/test/ziggurat/util/rabbitmq.clj
@@ -21,6 +21,15 @@
       (catch NullPointerException e
         nil))))
 
+(defn- get-msg-from-rabbitmq-without-ack [queue-name topic-name]
+  (with-open [ch (lch/open connection)]
+    (try
+      (let [[meta payload] (lb/get ch queue-name false)]
+        (when (seq payload)
+          (consumer/convert-message ch meta payload (keyword topic-name))))
+      (catch NullPointerException e
+        nil))))
+
 (defn get-msg-from-delay-queue [topic-name]
   (let [{:keys [queue-name]} (:delay (rabbitmq-config))
         queue-name (producer/delay-queue-name topic-name queue-name)]
@@ -30,6 +39,11 @@
   (let [{:keys [queue-name]} (:dead-letter (rabbitmq-config))
         queue-name (str topic-name "_" queue-name)]
     (get-msg-from-rabbitmq queue-name topic-name)))
+
+(defn get-msg-from-dead-queue-without-ack [topic-name]
+  (let [{:keys [queue-name]} (:dead-letter (rabbitmq-config))
+        queue-name (str topic-name "_" queue-name)]
+    (get-msg-from-rabbitmq-without-ack queue-name topic-name)))
 
 (defn get-msg-from-channel-dead-queue [topic-name channel-name]
   (let [{:keys [queue-name]} (:dead-letter (rabbitmq-config))

--- a/test/ziggurat/util/rabbitmq.clj
+++ b/test/ziggurat/util/rabbitmq.clj
@@ -26,7 +26,7 @@
     (try
       (let [[meta payload] (lb/get ch queue-name false)]
         (when (seq payload)
-          (consumer/convert-message ch meta payload (keyword topic-name))))
+          (consumer/convert-and-ack-message ch meta payload false (keyword topic-name))))
       (catch NullPointerException e
         nil))))
 


### PR DESCRIPTION
https://github.com/gojek/ziggurat/issues/115

This issue required ack-ing a message in a RabbitMQ message only after processing.

The existing function, `covert-and-ack-message` was being used in consumer.clj and dead_set.clj for both, reading (fetching) and consuming a message.

This PR has created two different methods for the same in consumer.clj, i.e. get-dead-set-messages and process-dead-set-messages. These have also been used in dead_set.clj for viewing, deleting and replaying the messages.
