### PR TITLE
Retries deadset messages when processing fails instead of pushing them back to dead queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file. This change
 
 ## Unreleased Changes
 
+## 3.2.0-alpha.5 - 2019-12-17
+- Fixes [issue](https://github.com/gojek/ziggurat/issues/136) where dead-set replay doesn't send the message to the retry-flow
+
 ## 3.2.0-alpha.4 - 2019-12-17
 - Fixes [issue](https://github.com/gojek/ziggurat/issues/129) by updating tools.nrepl dependency to nrepl/nrepl
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject tech.gojek/ziggurat "3.2.0-alpha.4"
+(defproject tech.gojek/ziggurat "3.2.0-alpha.5"
   :description "A stream processing framework to build stateless applications on kafka"
   :url "https://github.com/gojektech/ziggurat"
   :license {:name "Apache License, Version 2.0"

--- a/src/ziggurat/messaging/producer.clj
+++ b/src/ziggurat/messaging/producer.clj
@@ -6,7 +6,7 @@
             [langohr.queue :as lq]
             [sentry-clj.async :as sentry]
             [taoensso.nippy :as nippy]
-            [ziggurat.config :refer [ziggurat-config rabbitmq-config]]
+            [ziggurat.config :refer [ziggurat-config rabbitmq-config channel-retry-config]]
             [ziggurat.messaging.connection :refer [connection is-connection-required?]]
             [ziggurat.messaging.util :refer :all]
             [ziggurat.retry :refer [with-retry]]
@@ -73,14 +73,14 @@
                             "Pushing message to rabbitmq failed, data: " message-payload)))))
 
 (defn- get-channel-retry-count [topic-entity channel]
-  (-> (ziggurat-config) :stream-router topic-entity :channels channel :retry :count))
+  (:count (channel-retry-config topic-entity channel)))
 
 (defn- get-channel-retry-queue-timeout-ms [topic-entity channel]
-  (-> (ziggurat-config) :stream-router topic-entity :channels channel :retry :queue-timeout-ms))
+  (:queue-timeout-ms (channel-retry-config topic-entity channel)))
 
 (defn- channel-retries-exponential-backoff-config [topic-entity channel]
   "Get exponential backoff enabled for specific channel from config."
-  (-> (ziggurat-config) :stream-router topic-entity :channels channel :retry :exponential-backoff))
+  (:exponential-backoff (channel-retry-config topic-entity channel)))
 
 (defn- get-backoff-exponent [retry-count message-retry-count exponential-backoff-count]
   "Calculates backoff exponent for the given message-retry-count (number of retries available for the message) and retry-count (number of max retries possible). Returns the min of calculated exponent and exponential-backoff-count"

--- a/src/ziggurat/messaging/producer.clj
+++ b/src/ziggurat/messaging/producer.clj
@@ -198,14 +198,14 @@
     (cond
       (nil? retry-count) (publish-to-delay-queue (assoc message-payload :retry-count (dec (-> (ziggurat-config) :retry :count))))
       (pos? retry-count) (publish-to-delay-queue (assoc message-payload :retry-count (dec retry-count)))
-      (zero? retry-count) (publish-to-dead-queue message-payload))))
+      (zero? retry-count) (publish-to-dead-queue (assoc message-payload :retry-count (-> (ziggurat-config) :retry :count))))))
 
 (defn retry-for-channel [{:keys [retry-count topic-entity] :as message-payload} channel]
   (when (channel-retries-enabled topic-entity channel)
     (cond
       (nil? retry-count) (publish-to-channel-delay-queue channel (assoc message-payload :retry-count (dec (get-channel-retry-count topic-entity channel))))
       (pos? retry-count) (publish-to-channel-delay-queue channel (assoc message-payload :retry-count (dec retry-count)))
-      (zero? retry-count) (publish-to-channel-dead-queue channel message-payload))))
+      (zero? retry-count) (publish-to-channel-dead-queue channel (assoc message-payload :retry-count (get-channel-retry-count topic-entity channel))))))
 
 (defn- make-delay-queue [topic-entity]
   (let [{:keys [queue-name exchange-name dead-letter-exchange]} (:delay (rabbitmq-config))


### PR DESCRIPTION
Fixes issue: https://github.com/gojek/ziggurat/issues/136