### PR TITLE
Refactoring Retry Logic for Exponential Retries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@ All notable changes to this project will be documented in this file. This change
 
 ## Unreleased Changes
 
+## 3.2.0 - 2020-01-09
+- Changes Exponential backoff config contract.
+    - Adds a `:type` key to retry-config
+    - Adds a limit on the number of retries possible in exponential backoff
+    - Releasing exponential backoff as an alpha feature
+- Fixes [issue](https://github.com/gojek/ziggurat/issues/136) where dead-set replay doesn't send the message to the retry-flow
+- Fixes [issue](https://github.com/gojek/ziggurat/issues/129) by updating tools.nrepl dependency to nrepl/nrepl
+- Fixes [this bug](https://github.com/gojek/ziggurat/issues/133) where dead set replay broke on Ziggurat upgrade from 2.x to 3.x .
+- Fixes [this bug](https://github.com/gojek/ziggurat/issues/115) in RabbitMQ message processing flow
+- Adds support for exponential backoffs in channels and normal retry flow
+- exponential backoffs can be enabled from the config
+
 ## 3.2.0-alpha.5 - 2019-12-17
 - Fixes [issue](https://github.com/gojek/ziggurat/issues/136) where dead-set replay doesn't send the message to the retry-flow
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,9 +2,10 @@ version: '3.3'
 
 services:
   rabbitmq:
-    image: 'rabbitmq'
+    image: 'rabbitmq:3.8.2-management-alpine'
     ports:
      - '5672:5672'
+     - '15672:15672'
     container_name: 'ziggurat_rabbitmq'
   zookeeper:
     image: 'bitnami/zookeeper:latest'

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject tech.gojek/ziggurat "3.2.0-alpha.5"
+(defproject tech.gojek/ziggurat "3.2.0"
   :description "A stream processing framework to build stateless applications on kafka"
   :url "https://github.com/gojektech/ziggurat"
   :license {:name "Apache License, Version 2.0"

--- a/resources/config.test.ci.edn
+++ b/resources/config.test.ci.edn
@@ -24,7 +24,8 @@
                                                  :exchange-name "application_name_instant_exchange_test"}
                                    :dead-letter {:queue-name    "application_name_dead_letter_queue_test"
                                                  :exchange-name "application_name_dead_letter_exchange_test"}}
-            :retry                {:count   [5 :int]
+            :retry                {:type    [:linear :keyword]
+                                   :count   [5 :int]
                                    :enabled [true :bool]}
             :http-server          {:port         [8010 :int]
                                    :thread-count [100 :int]}
@@ -34,7 +35,8 @@
                                                           :origin-topic         "topic"
                                                           :upgrade-from         "1.1"
                                                           :channels             {:channel-1 {:worker-count [10 :int]
-                                                                                             :retry        {:count   [5 :int]
+                                                                                             :retry        {:type    [:linear :keyword]
+                                                                                                            :count   [5 :int]
                                                                                                             :enabled [true :bool]}}}
                                                           :producer             {:bootstrap-servers                     "localhost:9092"
                                                                                  :acks                                  "all"

--- a/resources/config.test.edn
+++ b/resources/config.test.edn
@@ -25,6 +25,7 @@
                                    :dead-letter {:queue-name    "application_name_dead_letter_queue_test"
                                                  :exchange-name "application_name_dead_letter_exchange_test"}}
             :retry                {:count   [5 :int]
+                                   :type    [:linear :keyword]
                                    :enabled [true :bool]}
             :http-server          {:port         [8010 :int]
                                    :thread-count [100 :int]}

--- a/resources/config.test.edn
+++ b/resources/config.test.edn
@@ -35,7 +35,8 @@
                                                           :origin-topic         "topic"
                                                           :upgrade-from         "1.1"
                                                           :channels             {:channel-1 {:worker-count [10 :int]
-                                                                                             :retry        {:count   [5 :int]
+                                                                                             :retry        {:type    [:linear :keyword]
+                                                                                                            :count   [5 :int]
                                                                                                             :enabled [true :bool]}}}
                                                           :producer             {:bootstrap-servers                     "localhost:9092"
                                                                                  :acks                                  "all"

--- a/src/ziggurat/messaging/producer.clj
+++ b/src/ziggurat/messaging/producer.clj
@@ -248,10 +248,10 @@
           (= :exponential channel-retry-type) (make-channel-delay-queue-with-retry-count topic-entity channel (get-channel-retry-count topic-entity channel))
           (= :linear channel-retry-type) (make-channel-delay-queue topic-entity channel)
           (nil? channel-retry-type) (do
-                         (log/warn "[Deprecation Notice]: Please note that the configuration for channel retries has changed."
-                                   "Please look at the upgrade guide for details: https://github.com/gojek/ziggurat/wiki/Upgrade-guide"
-                                   "Use :type to specify the type of retry mechanism in the channel config.")
-                         (make-channel-delay-queue topic-entity channel))
+                                      (log/warn "[Deprecation Notice]: Please note that the configuration for channel retries has changed."
+                                                "Please look at the upgrade guide for details: https://github.com/gojek/ziggurat/wiki/Upgrade-guide"
+                                                "Use :type to specify the type of retry mechanism in the channel config.")
+                                      (make-channel-delay-queue topic-entity channel))
           :else (do
                   (log/warn "Incorrect keyword for type passed, falling back to linear backoff for channel: " channel)
                   (make-channel-delay-queue topic-entity channel)))))))

--- a/src/ziggurat/messaging/producer.clj
+++ b/src/ziggurat/messaging/producer.clj
@@ -118,14 +118,12 @@
 
 (defn get-channel-queue-timeout-ms [topic-entity channel message-payload]
   "Calculate queue timeout for channel delay queue. Use value from get-exponential-backoff-timeout-ms if exponential backoff enabled."
-  (let [queue-timeout-ms (-> (rabbitmq-config) :delay :queue-timeout-ms)
-        channel-queue-timeout-ms (get-channel-retry-queue-timeout-ms topic-entity channel)
-        retry-count (-> (ziggurat-config) :retry :count)
+  (let [channel-queue-timeout-ms (get-channel-retry-queue-timeout-ms topic-entity channel)
         message-retry-count (:retry-count message-payload)
         channel-retry-count (get-channel-retry-count topic-entity channel)]
     (if (= :exponential (channel-retry-type topic-entity channel))
-      (get-exponential-backoff-timeout-ms (or channel-retry-count retry-count) message-retry-count (or channel-queue-timeout-ms queue-timeout-ms))
-      (or channel-queue-timeout-ms queue-timeout-ms))))
+      (get-exponential-backoff-timeout-ms channel-retry-count message-retry-count channel-queue-timeout-ms)
+      channel-queue-timeout-ms)))
 
 (defn get-delay-exchange-name [topic-entity message-payload]
   "This function return delay exchange name for retry when using flow without channel. It will return exchange name with retry count as suffix if exponential backoff enabled."

--- a/src/ziggurat/messaging/producer.clj
+++ b/src/ziggurat/messaging/producer.clj
@@ -249,7 +249,11 @@
       (make-channel-queue topic-entity channel :dead-letter)
       (let [channel-retry-type (channel-retry-type topic-entity channel)]
         (cond
-          (= :exponential channel-retry-type) (make-channel-delay-queue-with-retry-count topic-entity channel (get-channel-retry-count topic-entity channel))
+          (= :exponential channel-retry-type) (do
+                                                (log/warn "[Alpha Feature]: Exponential backoff based retries is an alpha feature."
+                                                          "Please use it only after understanding its risks and implications."
+                                                          "Its contract can change in the future releases of Ziggurat.")
+                                                (make-channel-delay-queue-with-retry-count topic-entity channel (get-channel-retry-count topic-entity channel)))
           (= :linear channel-retry-type) (make-channel-delay-queue topic-entity channel)
           (nil? channel-retry-type) (do
                                       (log/warn "[Deprecation Notice]: Please note that the configuration for channel retries has changed."
@@ -270,7 +274,11 @@
           (make-queue topic-entity :instant)
           (make-queue topic-entity :dead-letter)
           (cond
-            (= :exponential retry-type) (make-delay-queue-with-retry-count topic-entity (-> (ziggurat-config) :retry :count))
+            (= :exponential retry-type) (do
+                                          (log/warn "[Alpha Feature]: Exponential backoff based retries is an alpha feature."
+                                                    "Please use it only after understanding its risks and implications."
+                                                    "Its contract can change in the future releases of Ziggurat.")
+                                          (make-delay-queue-with-retry-count topic-entity (-> (ziggurat-config) :retry :count)))
             (= :linear retry-type)      (make-delay-queue topic-entity)
             (nil? retry-type)           (do
                                           (log/warn "[Deprecation Notice]: Please note that the configuration for retries has changed."

--- a/src/ziggurat/messaging/producer.clj
+++ b/src/ziggurat/messaging/producer.clj
@@ -158,7 +158,7 @@
         exchange-name (prefixed-channel-name topic-entity channel exchange-name)
         exponential-backoff-config (channel-retries-exponential-backoff-config topic-entity channel)
         channel-retry-count (get-channel-retry-count topic-entity channel)]
-    (if (= :exponential channel-retry-type)
+    (if (= :exponential (channel-retry-type topic-entity channel))
       (let [message-retry-count (:retry-count message-payload)
             exponential-backoff (get-backoff-exponent channel-retry-count message-retry-count (:count exponential-backoff-config))]
         (str (name exchange-name) "_" exponential-backoff))

--- a/test/ziggurat/messaging/consumer_test.clj
+++ b/test/ziggurat/messaging/consumer_test.clj
@@ -220,7 +220,7 @@
         (util/close ch)))))
 
 (deftest start-channels-subscriber-test
-  (testing "the mapper-fn for channel subscriber should be retried until return success when retry is enabled to for that channel"
+  (testing "the mapper-fn for channel subscriber should be retried until return success when retry is enabled for that channel"
     (let [retry-counter       (atom 0)
           call-counter        (atom 0)
           success-promise     (promise)

--- a/test/ziggurat/messaging/producer_test.clj
+++ b/test/ziggurat/messaging/producer_test.clj
@@ -453,7 +453,15 @@
                                                                                                                           :enabled             true
                                                                                                                           :type                :exponential
                                                                                                                           :queue-timeout-ms    1000}}}}}))]
-          (is (= 7000 (producer/get-channel-queue-timeout-ms topic-entity channel message))))))))
+          (is (= 7000 (producer/get-channel-queue-timeout-ms topic-entity channel message))))))
+
+  (testing "when exponential backoff are enabled and channel queue timeout is not defined"
+    (let [channel :exponential-retry]
+      (with-redefs [config/ziggurat-config (constantly (assoc (config/ziggurat-config)
+                                                         :stream-router {topic-entity {:channels {channel {:retry {:count               5
+                                                                                                                   :enabled             true
+                                                                                                                   :type                :exponential}}}}}))]
+        (is (= 700 (producer/get-channel-queue-timeout-ms topic-entity channel message))))))))
 
 (deftest get-queue-timeout-ms-test
   (testing "when retries are enabled"

--- a/test/ziggurat/messaging/producer_test.clj
+++ b/test/ziggurat/messaging/producer_test.clj
@@ -252,7 +252,16 @@
                 expected-message      (assoc message-payload :retry-count 0)]
             (producer/retry retry-message-payload)
             (let [message-from-mq (rmq/get-message-from-retry-queue "default" 5)]
-              (is (= message-from-mq expected-message)))))))))
+              (is (= message-from-mq expected-message))))))
+
+      (testing "message will be retried in delay queue with suffix 1 if message retry-count exceeds retry count in config"
+          (fix/with-queues
+            {:default {:handler-fn #(constantly nil)}}
+            (let [retry-message-payload    (assoc message-payload :retry-count 10)
+                  expected-message-payload (assoc message-payload :retry-count 9)]
+              (producer/retry retry-message-payload)
+              (let [message-from-mq (rmq/get-message-from-retry-queue "default" 1)]
+                (is (= message-from-mq expected-message-payload)))))))))
 
 (deftest make-queues-test
   (let [ziggurat-config (ziggurat-config)]

--- a/test/ziggurat/messaging/producer_test.clj
+++ b/test/ziggurat/messaging/producer_test.clj
@@ -58,23 +58,23 @@
 
   (testing "message in channel will be retried in delay queue with suffix 1 if message retry-count exceeds retry count in channel config"
     (with-redefs [ziggurat-config (constantly (assoc (ziggurat-config)
-                                                :stream-router
-                                                {:default
-                                                 {:channels
-                                                  {:exponential-retry
-                                                   {:retry {:count 5
-                                                            :enabled          true
-                                                            :type             :exponential
-                                                            :queue-timeout-ms 1000}}}}}))]
-    (fix/with-queues
-      {:default {:handler-fn #(constantly nil)
-                 :exponential-retry  #(constantly nil)}}
-      (let [channel                  :exponential-retry
-            retry-message-payload    (assoc message-payload :retry-count 10)
-            expected-message-payload (assoc message-payload :retry-count 9)
-            _                        (producer/retry-for-channel retry-message-payload channel)
-            message-from-mq          (rmq/get-message-from-channel-retry-queue topic-entity channel 1)]
-        (is (= expected-message-payload message-from-mq))))))
+                                                     :stream-router
+                                                     {:default
+                                                      {:channels
+                                                       {:exponential-retry
+                                                        {:retry {:count 5
+                                                                 :enabled          true
+                                                                 :type             :exponential
+                                                                 :queue-timeout-ms 1000}}}}}))]
+      (fix/with-queues
+        {:default {:handler-fn #(constantly nil)
+                   :exponential-retry  #(constantly nil)}}
+        (let [channel                  :exponential-retry
+              retry-message-payload    (assoc message-payload :retry-count 10)
+              expected-message-payload (assoc message-payload :retry-count 9)
+              _                        (producer/retry-for-channel retry-message-payload channel)
+              message-from-mq          (rmq/get-message-from-channel-retry-queue topic-entity channel 1)]
+          (is (= expected-message-payload message-from-mq))))))
 
   (testing "message in channel will be retried with linear queue timeout"
     (with-redefs [ziggurat-config (constantly (assoc (ziggurat-config)

--- a/test/ziggurat/messaging/producer_test.clj
+++ b/test/ziggurat/messaging/producer_test.clj
@@ -323,7 +323,74 @@
               (lq/delete ch dead-queue-name)
               (le/delete ch delay-exchange-name)
               (le/delete ch instant-exchange-name)
-              (le/delete ch dead-exchange-name))))))
+              (le/delete ch dead-exchange-name))))
+        (testing "it creates queues with suffixes in the range [1, retry-count] when exponential backoff is enabled"
+          (with-open [ch (lch/open connection)]
+            (let [stream-routes         {:default {:handler-fn #(constantly :success)}}
+                  retry-count           (get-in ziggurat-config [:retry :count])
+                  instant-queue-name    (util/prefixed-queue-name "default" (:queue-name (:instant (rabbitmq-config))))
+                  instant-exchange-name (util/prefixed-queue-name "default" (:exchange-name (:instant (rabbitmq-config))))
+                  delay-queue-name      (util/prefixed-queue-name "default" (:queue-name (:delay (rabbitmq-config))))
+                  delay-exchange-name   (util/prefixed-queue-name "default" (:exchange-name (:delay (rabbitmq-config))))
+                  dead-queue-name       (util/prefixed-queue-name "default" (:queue-name (:dead-letter (rabbitmq-config))))
+                  dead-exchange-name    (util/prefixed-queue-name "default" (:exchange-name (:dead-letter (rabbitmq-config))))
+                  expected-queue-status {:message-count 0 :consumer-count 0}
+                  exponential-delay-queue-name #(util/prefixed-queue-name delay-queue-name %)
+                  exponential-delay-exchange-name #(util/prefixed-queue-name delay-exchange-name %)]
+
+              (with-redefs [config/ziggurat-config (constantly (assoc-in ziggurat-config [:retry :type] :exponential))]
+                (producer/make-queues stream-routes)
+
+                (is (= expected-queue-status (lq/status ch dead-queue-name)))
+                (is (= expected-queue-status (lq/status ch instant-queue-name)))
+                (lq/delete ch instant-queue-name)
+                (lq/delete ch dead-queue-name)
+                (le/delete ch instant-exchange-name)
+                (le/delete ch dead-exchange-name)
+
+                ;; Verifying that delay queues with appropriate suffixes have been created
+                (doseq [s (range 1 (inc retry-count))]
+                  (is (= expected-queue-status (lq/status ch (exponential-delay-queue-name s))))
+                  (lq/delete ch (exponential-delay-queue-name s))
+                  (le/delete ch (exponential-delay-exchange-name s)))))))
+        (testing "it creates delay queue for linear retries when retry type is not defined in the config"
+          (let [make-delay-queue-called (atom false)
+                stream-routes          {:test  {:handler-fn #(constantly nil)}}]
+            (with-redefs [config/ziggurat-config (constantly (update-in ziggurat-config [:retry] dissoc :type))
+                          producer/make-queue       (constantly nil)
+                          producer/make-delay-queue (fn [topic]
+                                                      (if (= topic :test)
+                                                        (reset! make-delay-queue-called true)))]
+              (producer/make-queues stream-routes))))
+        (testing "it creates delay queue for linear retries when retry type is incorrectly defined in the config"
+          (let [make-delay-queue-called (atom false)
+                stream-routes          {:test  {:handler-fn #(constantly nil)}}]
+            (with-redefs [config/ziggurat-config (constantly (assoc-in ziggurat-config [:retry :type] :incorrect))
+                          producer/make-queue       (constantly nil)
+                          producer/make-delay-queue (fn [topic]
+                                                      (if (= topic :test)
+                                                        (reset! make-delay-queue-called true)))]
+              (producer/make-queues stream-routes))))
+        (testing "it creates channel delay queue for linear retries when retry type is not defined in the channel config"
+          (let [make-channel-delay-queue-called (atom false)
+                stream-routes          {:test       {:handler-fn #(constantly nil)}
+                                        :channel-1  {:handler-fn #(constantly nil)}}]
+            (with-redefs [config/ziggurat-config    (constantly (update-in ziggurat-config [:stream-router :default :channels :channel-1 :retry] dissoc :type))
+                          producer/make-channel-queue       (constantly nil)
+                          producer/make-channel-delay-queue (fn [topic]
+                                                              (if (= topic :test)
+                                                                (reset! make-channel-delay-queue-called true)))]
+              (producer/make-queues stream-routes))))
+        (testing "it creates channel delay queue for linear retries when an incorrect retry type is defined in the channel config"
+          (let [make-channel-delay-queue-called (atom false)
+                stream-routes          {:test       {:handler-fn #(constantly nil)}
+                                        :channel-1  {:handler-fn #(constantly nil)}}]
+            (with-redefs [config/ziggurat-config    (constantly (assoc-in ziggurat-config [:stream-router :default :channels :channel-1 :retry :type] :incorrect))
+                          producer/make-channel-queue       (constantly nil)
+                          producer/make-channel-delay-queue (fn [topic]
+                                                              (if (= topic :test)
+                                                                (reset! make-channel-delay-queue-called true)))]
+              (producer/make-queues stream-routes))))))
 
     (testing "when retries are disabled"
       (with-redefs [config/ziggurat-config (constantly (assoc ziggurat-config

--- a/test/ziggurat/messaging/producer_test.clj
+++ b/test/ziggurat/messaging/producer_test.clj
@@ -255,13 +255,13 @@
               (is (= message-from-mq expected-message))))))
 
       (testing "message will be retried in delay queue with suffix 1 if message retry-count exceeds retry count in config"
-          (fix/with-queues
-            {:default {:handler-fn #(constantly nil)}}
-            (let [retry-message-payload    (assoc message-payload :retry-count 10)
-                  expected-message-payload (assoc message-payload :retry-count 9)]
-              (producer/retry retry-message-payload)
-              (let [message-from-mq (rmq/get-message-from-retry-queue "default" 1)]
-                (is (= message-from-mq expected-message-payload)))))))))
+        (fix/with-queues
+          {:default {:handler-fn #(constantly nil)}}
+          (let [retry-message-payload    (assoc message-payload :retry-count 10)
+                expected-message-payload (assoc message-payload :retry-count 9)]
+            (producer/retry retry-message-payload)
+            (let [message-from-mq (rmq/get-message-from-retry-queue "default" 1)]
+              (is (= message-from-mq expected-message-payload)))))))))
 
 (deftest make-queues-test
   (let [ziggurat-config (ziggurat-config)]

--- a/test/ziggurat/messaging/producer_test.clj
+++ b/test/ziggurat/messaging/producer_test.clj
@@ -455,13 +455,13 @@
                                                                                                                           :queue-timeout-ms    1000}}}}}))]
           (is (= 7000 (producer/get-channel-queue-timeout-ms topic-entity channel message))))))
 
-  (testing "when exponential backoff are enabled and channel queue timeout is not defined"
-    (let [channel :exponential-retry]
-      (with-redefs [config/ziggurat-config (constantly (assoc (config/ziggurat-config)
-                                                         :stream-router {topic-entity {:channels {channel {:retry {:count               5
-                                                                                                                   :enabled             true
-                                                                                                                   :type                :exponential}}}}}))]
-        (is (= 700 (producer/get-channel-queue-timeout-ms topic-entity channel message))))))))
+    (testing "when exponential backoff are enabled and channel queue timeout is not defined"
+      (let [channel :exponential-retry]
+        (with-redefs [config/ziggurat-config (constantly (assoc (config/ziggurat-config)
+                                                                :stream-router {topic-entity {:channels {channel {:retry {:count               5
+                                                                                                                          :enabled             true
+                                                                                                                          :type                :exponential}}}}}))]
+          (is (= 700 (producer/get-channel-queue-timeout-ms topic-entity channel message))))))))
 
 (deftest get-queue-timeout-ms-test
   (testing "when retries are enabled"

--- a/test/ziggurat/messaging/producer_test.clj
+++ b/test/ziggurat/messaging/producer_test.clj
@@ -56,6 +56,26 @@
         (let [message-from-mq (rmq/get-msg-from-channel-dead-queue topic-entity channel)]
           (is (= expected-message-payload message-from-mq))))))
 
+  (testing "message in channel will be retried in delay queue with suffix 1 if message retry-count exceeds retry count in channel config"
+    (with-redefs [ziggurat-config (constantly (assoc (ziggurat-config)
+                                                :stream-router
+                                                {:default
+                                                 {:channels
+                                                  {:exponential-retry
+                                                   {:retry {:count 5
+                                                            :enabled          true
+                                                            :type             :exponential
+                                                            :queue-timeout-ms 1000}}}}}))]
+    (fix/with-queues
+      {:default {:handler-fn #(constantly nil)
+                 :exponential-retry  #(constantly nil)}}
+      (let [channel                  :exponential-retry
+            retry-message-payload    (assoc message-payload :retry-count 10)
+            expected-message-payload (assoc message-payload :retry-count 9)
+            _                        (producer/retry-for-channel retry-message-payload channel)
+            message-from-mq          (rmq/get-message-from-channel-retry-queue topic-entity channel 1)]
+        (is (= expected-message-payload message-from-mq))))))
+
   (testing "message in channel will be retried with linear queue timeout"
     (with-redefs [ziggurat-config (constantly (assoc (ziggurat-config)
                                                      :stream-router {:default {:channels {:linear-retry {:retry {:count            5

--- a/test/ziggurat/messaging/producer_test.clj
+++ b/test/ziggurat/messaging/producer_test.clj
@@ -576,8 +576,8 @@
   (testing "when exponential retries are enabled and retry-count exceeds 25, the max possible timeouts are calculated using 25 as the retry-count"
     (let [message (assoc message-payload :retry-count 20)]
       (with-redefs [config/ziggurat-config (constantly (assoc (config/ziggurat-config)
-                                                         :retry {:enabled             true
-                                                                 :count               50
-                                                                 :type                :exponential}))]
+                                                              :retry {:enabled             true
+                                                                      :count               50
+                                                                      :type                :exponential}))]
         ;; For 25 max exponential retries, exponent comes to 25-20=5, which makes timeout = 100*(2^5-1) = 3100
         (is (= 3100 (producer/get-queue-timeout-ms message)))))))


### PR DESCRIPTION
- Introduces retry types [:linear, :exponential]
- Removed the usage of retry-limits in case of exponential retries
- Introduces queue-timeout-ms for channels