### PR TITLE
[Issue-144] Uses clojusc/protobuf for default middleware

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -31,7 +31,7 @@
                  [org.clojure/clojure "1.10.0"]
                  [org.clojure/tools.logging "0.5.0"]
                  [nrepl/nrepl "0.6.0"]
-                 [org.flatland/protobuf "0.8.1"]
+                 [clojusc/protobuf "3.5.1-v1.1"]
                  [prismatic/schema "1.1.12"]
                  [ring/ring "1.7.1"]
                  [ring/ring-core "1.7.1"]
@@ -60,6 +60,7 @@
                                       [org.apache.kafka/kafka-streams "2.1.0" :classifier "test" :exclusions [org.slf4j/slf4j-log4j12 log4j]]
                                       [org.apache.kafka/kafka-clients "2.1.0" :classifier "test"]
                                       [org.apache.kafka/kafka_2.11 "2.1.0" :classifier "test"]
+                                      [org.flatland/protobuf "0.8.1"]
                                       [org.clojure/test.check "0.10.0"]]
                        :plugins      [[lein-cloverage "1.0.13" :exclusions [org.clojure/clojure]]]
                        :repositories [["confluent-repo" "https://packages.confluent.io/maven/"]]}

--- a/src/ziggurat/middleware/default.clj
+++ b/src/ziggurat/middleware/default.clj
@@ -1,5 +1,5 @@
 (ns ziggurat.middleware.default
-  (:require [flatland.protobuf.core :as proto]
+  (:require [protobuf.impl.flatland.mapdef :as protodef]
             [sentry-clj.async :as sentry]
             [ziggurat.config :refer [ziggurat-config]]
             [ziggurat.metrics :as metrics]
@@ -14,10 +14,10 @@
   [message proto-class topic-entity-name]
   (if-not (map? message)
     (try
-      (let [proto-klass  (proto/protodef proto-class)
-            loaded-proto (proto/protobuf-load proto-klass message)
+      (let [proto-klass (protodef/mapdef proto-class)
+            loaded-proto (protodef/parse proto-klass message)
             proto-keys   (-> proto-klass
-                             proto/protobuf-schema
+                             protodef/mapdef->schema
                              :fields
                              keys)]
         (select-keys loaded-proto proto-keys))

--- a/test/ziggurat/middleware/default_test.clj
+++ b/test/ziggurat/middleware/default_test.clj
@@ -1,7 +1,7 @@
 (ns ziggurat.middleware.default-test
   (:require [clojure.test :refer :all]
-            [flatland.protobuf.core :as proto]
             [sentry-clj.async :as sentry]
+            [protobuf.core :as proto]
             [ziggurat.fixtures :as fix]
             [ziggurat.metrics :as metrics]
             [ziggurat.middleware.default :refer :all])
@@ -17,7 +17,7 @@
                               :path "/photos/h2k3j4h9h23"}
           proto-class        Example$Photo
           topic-entity-name  "test"
-          proto-message      (proto/protobuf-dump (proto/protodef Example$Photo) message)
+          proto-message      (proto/->bytes (proto/create Example$Photo message))
           handler-fn         (fn [msg]
                                (if (= msg message)
                                  (reset! handler-fn-called? true)))]

--- a/test/ziggurat/streams_test.clj
+++ b/test/ziggurat/streams_test.clj
@@ -1,6 +1,6 @@
 (ns ziggurat.streams-test
   (:require [clojure.test :refer :all]
-            [flatland.protobuf.core :as proto]
+            [protobuf.core :as proto]
             [ziggurat.streams :refer [start-streams stop-streams]]
             [ziggurat.fixtures :as fix]
             [ziggurat.config :refer [ziggurat-config]]
@@ -36,7 +36,7 @@
 (def proto-class Example$Photo)
 
 (defn create-photo []
-  (proto/protobuf-dump (proto/protodef proto-class) message))
+  (proto/->bytes (proto/create proto-class message)))
 
 (def message-key-value (KeyValue/pair (create-photo) (create-photo)))
 


### PR DESCRIPTION
 Resolves #144  Uses clojusc/protobuf instead of org.flatland/protobuf for default middleware