### PR TITLE
Make message producer publish method to public

### DIFF
--- a/src/ziggurat/messaging/producer.clj
+++ b/src/ziggurat/messaging/producer.clj
@@ -60,7 +60,7 @@
       (assoc props :expiration (str expiration))
       props)))
 
-(defn- publish
+(defn publish
   ([exchange message-payload]
    (publish exchange message-payload nil))
   ([exchange message-payload expiration]


### PR DESCRIPTION
It will be helpful for directly publishing messages to the delayed queue.