### PR TITLE
refactors metrics.clj

### DIFF
--- a/src/ziggurat/dropwizard_metric_wrapper_test.clj
+++ b/src/ziggurat/dropwizard_metric_wrapper_test.clj
@@ -1,0 +1,43 @@
+(ns ziggurat.dropwizard-metric-wrapper-test
+  (:require [ziggurat.dropwizard-metrics-wrapper :refer :all]
+            [ziggurat.config :refer [ziggurat-config]]
+            [clojure.test :refer :all]
+            [clojure.walk :refer [stringify-keys]])
+  (:import [io.dropwizard.metrics5 Meter Histogram]))
+
+
+(deftest mk-meter-test
+  (let [category     "category"
+        metric       "metric1"
+        service-name (:app-name (ziggurat-config))]
+    (testing "returns a meter"
+      (let [expected-tags {"actor" service-name}]
+        (with-redefs [get-tagged-metric (fn [metric-name tags]
+                                          (is (= tags expected-tags))
+                                          (.tagged metric-name tags))]
+          (is (instance? Meter (mk-meter category metric))))))
+    (testing "returns a meter - with additional-tags"
+      (let [additional-tags {:foo "bar"}
+            expected-tags   (merge {"actor" service-name} (stringify-keys additional-tags))]
+        (with-redefs [get-tagged-metric (fn [metric-name tags]
+                                          (is (= tags expected-tags))
+                                          (.tagged metric-name tags))]
+          (is (instance? Meter (mk-meter category metric additional-tags))))))))
+
+(deftest mk-histogram-test
+  (let [category     "category"
+        metric       "metric2"
+        service-name (:app-name (ziggurat-config))]
+    (testing "returns a histogram"
+      (let [expected-tags {"actor" service-name}]
+        (with-redefs [get-tagged-metric (fn [metric-name tags]
+                                                  (is (= tags expected-tags))
+                                                  (.tagged metric-name tags))]
+          (is (instance? Histogram (mk-histogram category metric))))))
+    (testing "returns a histogram - with additional-tags"
+      (let [additional-tags {:foo "bar"}
+            expected-tags   (merge {"actor" service-name} (stringify-keys additional-tags))]
+        (with-redefs [get-tagged-metric (fn [metric-name tags]
+                                                  (is (= tags expected-tags))
+                                                  (.tagged metric-name tags))]
+          (is (instance? Histogram (mk-histogram category metric additional-tags))))))))

--- a/src/ziggurat/dropwizard_metric_wrapper_test.clj
+++ b/src/ziggurat/dropwizard_metric_wrapper_test.clj
@@ -41,3 +41,4 @@
                                                   (is (= tags expected-tags))
                                                   (.tagged metric-name tags))]
           (is (instance? Histogram (mk-histogram category metric additional-tags))))))))
+

--- a/src/ziggurat/dropwizard_metrics_wrapper.clj
+++ b/src/ziggurat/dropwizard_metrics_wrapper.clj
@@ -49,7 +49,7 @@
 
 (defn mk-histogram
   ([category metric]
-   (mk-histogram category metric nil))
+   (mk-histogram category metric {}))
   ([category metric tags]
    (let [namespace        (str category "." metric)
          metric-name      (MetricRegistry/name ^String namespace nil)

--- a/src/ziggurat/dropwizard_metrics_wrapper.clj
+++ b/src/ziggurat/dropwizard_metrics_wrapper.clj
@@ -1,0 +1,68 @@
+(ns ziggurat.dropwizard-metrics-wrapper
+  (:require [clojure.tools.logging :as log]
+            [ziggurat.config :refer [ziggurat-config]]
+            [clojure.walk :refer [stringify-keys]])
+  (:import [com.gojek.metrics.datadog.transport UdpTransport UdpTransport$Builder]
+           [io.dropwizard.metrics5 MetricRegistry]
+           [com.gojek.metrics.datadog DatadogReporter]
+           [java.util.concurrent TimeUnit]
+           [io.dropwizard.metrics5 Histogram Meter MetricName MetricRegistry]))
+
+
+(defonce metrics-registry
+         (MetricRegistry.))
+
+(defn initialize [statsd-config]
+  (let [{:keys [enabled host port]} statsd-config]
+    (when enabled
+      (let [transport (-> (UdpTransport$Builder.)
+                          (.withStatsdHost host)
+                          (.withPort port)
+                          (.build))
+
+            reporter  (-> (DatadogReporter/forRegistry metrics-registry)
+                          (.withTransport transport)
+                          (.build))]
+        (log/info "Starting statsd reporter")
+        (.start reporter 1 TimeUnit/SECONDS)
+        {:reporter reporter :transport transport}))))
+
+(defn terminate [datadog-reporter]
+  (when-let [{:keys [reporter transport]} datadog-reporter]
+    (.stop ^DatadogReporter reporter)
+    (.close ^UdpTransport transport)
+    (log/info "Stopped statsd reporter")))
+
+
+;;TODO: remove this from here, we need to pass all the tags directly to the library instead of us constructing them here
+(defn- merge-tags
+  [additional-tags]
+  (let [{:keys [app-name env]} (ziggurat-config)
+        default-tags {"actor" app-name
+                      "env"   env}]
+    (merge default-tags (stringify-keys additional-tags))))
+
+(defn- get-tagged-metric
+  [metric-name tags]
+  (.tagged ^MetricName metric-name tags))
+
+(defn mk-meter
+  ([category metric]
+   (mk-meter category metric nil))
+  ([category metric additional-tags]
+   (let [namespace     (str category "." metric)
+         metric-name   (MetricRegistry/name ^String namespace nil)
+         tags          (merge-tags additional-tags)
+         tagged-metric (get-tagged-metric metric-name tags)]
+     (.meter ^MetricRegistry metrics-registry ^MetricName tagged-metric))))
+
+(defn mk-histogram
+  ([category metric]
+   (mk-histogram category metric nil))
+  ([category metric additional-tags]
+   (let [namespace     (str category "." metric)
+         metric-name   (MetricRegistry/name ^String namespace nil)
+         tags          (merge-tags additional-tags)
+         tagged-metric (.tagged ^MetricName metric-name tags)]
+     (.histogram ^MetricRegistry metrics-registry ^MetricName tagged-metric))))
+

--- a/src/ziggurat/dropwizard_metrics_wrapper.clj
+++ b/src/ziggurat/dropwizard_metrics_wrapper.clj
@@ -38,7 +38,7 @@
 
 (defn mk-meter
   ([category metric]
-   (mk-meter category metric nil))
+   (mk-meter category metric {}))
   ([category metric tags]
    (let [namespace        (str category "." metric)
          metric-name      (MetricRegistry/name ^String namespace nil)

--- a/src/ziggurat/dropwizard_metrics_wrapper.clj
+++ b/src/ziggurat/dropwizard_metrics_wrapper.clj
@@ -8,9 +8,8 @@
            [java.util.concurrent TimeUnit]
            [io.dropwizard.metrics5 Histogram Meter MetricName MetricRegistry]))
 
-
 (defonce metrics-registry
-         (MetricRegistry.))
+  (MetricRegistry.))
 
 (defn initialize [statsd-config]
   (let [{:keys [enabled host port]} statsd-config]
@@ -60,7 +59,7 @@
 (defn update-counter
   [namespace metric tags sign value]
   (let [meter (mk-meter namespace metric tags)]
-   (.mark ^Meter meter (sign value))))
+    (.mark ^Meter meter (sign value))))
 
 (defn update-histogram
   [namespace tags value]

--- a/src/ziggurat/init.clj
+++ b/src/ziggurat/init.clj
@@ -19,7 +19,6 @@
    :methods [^{:static true} [init [java.util.Map] void]]
    :name tech.gojek.ziggurat.internal.Init))
 
-
 (defn- start*
   ([states]
    (start* states nil))

--- a/src/ziggurat/init.clj
+++ b/src/ziggurat/init.clj
@@ -19,10 +19,6 @@
    :methods [^{:static true} [init [java.util.Map] void]]
    :name tech.gojek.ziggurat.internal.Init))
 
-(defstate statsd-reporter
-  :start (metrics/start-statsd-reporter (config/statsd-config)
-                                        (:env (ziggurat-config)))
-  :stop (metrics/stop-statsd-reporter statsd-reporter))
 
 (defn- start*
   ([states]
@@ -112,14 +108,14 @@
 
 (defn start-common-states []
   (start* #{#'config/config
-            #'statsd-reporter
+            #'metrics/statsd-reporter
             #'sentry-reporter
             #'nrepl-server/server
             #'tracer/tracer}))
 
 (defn stop-common-states []
   (mount/stop #'config/config
-              #'statsd-reporter
+              #'metrics/statsd-reporter
               #'messaging-connection/connection
               #'nrepl-server/server
               #'tracer/tracer))

--- a/src/ziggurat/metrics.clj
+++ b/src/ziggurat/metrics.clj
@@ -15,7 +15,7 @@
              ^{:static true} [reportTime [String long java.util.Map] void]]))
 
 (defstate statsd-reporter
-  :start (metrics-lib/initialize (:datadog (ziggurat-config)))
+  :start (metrics-lib/initialize (:statsd (ziggurat-config)))
   :stop (metrics-lib/terminate statsd-reporter))
 
 (defn intercalate-dot

--- a/src/ziggurat/metrics.clj
+++ b/src/ziggurat/metrics.clj
@@ -114,7 +114,6 @@
   (log/warn "Deprecation Notice: This function is deprecated in favour of ziggurat.metrics/multi-ns-report-histogram. Both functions have the same interface, so please use that function. It will be removed in future releases.")
   (multi-ns-report-histogram nss time-val additional-tags))
 
-
 (defn -incrementCount
   ([metric-namespace metric]
    (increment-count metric-namespace metric))

--- a/src/ziggurat/metrics.clj
+++ b/src/ziggurat/metrics.clj
@@ -89,7 +89,6 @@
   ([metric-namespaces val additional-tags]
    (let [intercalated-metric-namespaces (get-metric-namespaces metric-namespaces)
          tags                           (remove-topic-tag-for-old-namespace (get-all-tags additional-tags metric-namespaces) metric-namespaces)
-         make-histogram-for-namespace   #(metrics-lib/mk-histogram % "all" tags)
          integer-value                  (get-int val)]
      (doseq [metric-ns intercalated-metric-namespaces]
        (metrics-lib/update-histogram metric-ns tags integer-value)))))

--- a/src/ziggurat/metrics.clj
+++ b/src/ziggurat/metrics.clj
@@ -29,6 +29,13 @@
   (let [topic-name (:topic_name additional-tags)]
     (dissoc additional-tags (when (some #(= % topic-name) ns) :topic_name))))
 
+(defn- get-all-tags
+  [additional-tags metric-namespaces]
+  (let [{:keys [app-name env]} (ziggurat-config)
+        default-tags {:actor (name app-name)
+                      :env   (name env)}]
+    (merge additional-tags default-tags)))
+
 (defn- get-metric-namespaces
   [metric-namespaces]
   (if (vector? metric-namespaces)
@@ -62,10 +69,11 @@
   ([sign metric-namespace metric n additional-tags]
    (inc-or-dec-count sign {:metric-namespace metric-namespace :metric metric :n n :additional-tags additional-tags}))
   ([sign {:keys [metric-namespace metric n additional-tags]}]
-   (let [metric-namespaces        (get-metric-namespaces metric-namespace)
-         make-meter-for-namespace #(metrics-lib/mk-meter % metric (remove-topic-tag-for-old-namespace (get-map additional-tags) metric-namespace))]
+   (let [metric-namespaces (get-metric-namespaces metric-namespace)
+         tags              (remove-topic-tag-for-old-namespace (get-all-tags (get-map additional-tags) metric-namespaces) metric-namespace)
+         integer-value     (get-int n)]
      (doseq [metric-ns metric-namespaces]
-       (.mark ^Meter (make-meter-for-namespace metric-ns) (sign (get-int n)))))))
+       (metrics-lib/update-counter metric-ns metric tags sign integer-value)))))
 
 (def increment-count (partial inc-or-dec-count +))
 
@@ -80,10 +88,11 @@
    (report-histogram metric-namespaces val nil))
   ([metric-namespaces val additional-tags]
    (let [intercalated-metric-namespaces (get-metric-namespaces metric-namespaces)
-
-         make-histogram-for-namespace   #(metrics-lib/mk-histogram % "all" (remove-topic-tag-for-old-namespace additional-tags metric-namespaces))]
+         tags                           (remove-topic-tag-for-old-namespace (get-all-tags additional-tags metric-namespaces) metric-namespaces)
+         make-histogram-for-namespace   #(metrics-lib/mk-histogram % "all" tags)
+         integer-value                  (get-int val)]
      (doseq [metric-ns intercalated-metric-namespaces]
-       (.update (make-histogram-for-namespace metric-ns) (get-int val))))))
+       (metrics-lib/update-histogram metric-ns tags integer-value)))))
 
 (defn report-time
   "This function is an alias for `report-histogram`.

--- a/src/ziggurat/metrics.clj
+++ b/src/ziggurat/metrics.clj
@@ -6,17 +6,17 @@
             [mount.core :refer [defstate]]
             [ziggurat.dropwizard-metrics-wrapper :as metrics-lib])
   (:gen-class
-    :name tech.gojek.ziggurat.internal.Metrics
-    :methods [^{:static true} [incrementCount [String String] void]
-              ^{:static true} [incrementCount [String String java.util.Map] void]
-              ^{:static true} [decrementCount [String String] void]
-              ^{:static true} [decrementCount [String String java.util.Map] void]
-              ^{:static true} [reportTime [String long] void]
-              ^{:static true} [reportTime [String long java.util.Map] void]]))
+   :name tech.gojek.ziggurat.internal.Metrics
+   :methods [^{:static true} [incrementCount [String String] void]
+             ^{:static true} [incrementCount [String String java.util.Map] void]
+             ^{:static true} [decrementCount [String String] void]
+             ^{:static true} [decrementCount [String String java.util.Map] void]
+             ^{:static true} [reportTime [String long] void]
+             ^{:static true} [reportTime [String long java.util.Map] void]]))
 
 (defstate statsd-reporter
-          :start (metrics-lib/initialize (:datadog (ziggurat-config)))
-          :stop (metrics-lib/terminate statsd-reporter))
+  :start (metrics-lib/initialize (:datadog (ziggurat-config)))
+  :stop (metrics-lib/terminate statsd-reporter))
 
 (defn intercalate-dot
   [names]

--- a/src/ziggurat/metrics.clj
+++ b/src/ziggurat/metrics.clj
@@ -1,7 +1,7 @@
 (ns ziggurat.metrics
   (:require [clojure.string :as str]
             [clojure.tools.logging :as log]
-            [ziggurat.config :refer [ziggurat-config]]
+            [ziggurat.config :refer [statsd-config ziggurat-config]]
             [ziggurat.util.java-util :as util]
             [mount.core :refer [defstate]]
             [ziggurat.dropwizard-metrics-wrapper :as metrics-lib])
@@ -15,8 +15,10 @@
              ^{:static true} [reportTime [String long java.util.Map] void]]))
 
 (defstate statsd-reporter
-  :start (metrics-lib/initialize (:statsd (ziggurat-config)))
-  :stop (metrics-lib/terminate statsd-reporter))
+  :start (do (log/info "Initializing Metrics")
+             (metrics-lib/initialize statsd-config))
+  :stop (do (log/info "Terminating Metrics")
+            (metrics-lib/terminate)))
 
 (defn intercalate-dot
   [names]

--- a/src/ziggurat/metrics.clj
+++ b/src/ziggurat/metrics.clj
@@ -3,7 +3,8 @@
             [clojure.tools.logging :as log]
             [clojure.walk :refer [stringify-keys]]
             [ziggurat.config :refer [ziggurat-config]]
-            [ziggurat.util.java-util :as util])
+            [ziggurat.util.java-util :as util]
+            [mount.core :refer [defstate]])
   (:import com.gojek.metrics.datadog.DatadogReporter
            [com.gojek.metrics.datadog.transport UdpTransport UdpTransport$Builder]
            [io.dropwizard.metrics5 Histogram Meter MetricName MetricRegistry]
@@ -156,6 +157,11 @@
     (.stop ^DatadogReporter reporter)
     (.close ^UdpTransport transport)
     (log/info "Stopped statsd reporter")))
+
+(defstate statsd-reporter
+          :start (start-statsd-reporter (:datadog (ziggurat-config))
+                                                (:env (ziggurat-config)))
+          :stop (stop-statsd-reporter statsd-reporter))
 
 (defn -incrementCount
   ([metric-namespace metric]

--- a/src/ziggurat/metrics.clj
+++ b/src/ziggurat/metrics.clj
@@ -1,12 +1,10 @@
 (ns ziggurat.metrics
   (:require [clojure.string :as str]
             [clojure.tools.logging :as log]
-            [clojure.walk :refer [stringify-keys]]
             [ziggurat.config :refer [ziggurat-config]]
             [ziggurat.util.java-util :as util]
             [mount.core :refer [defstate]]
             [ziggurat.dropwizard-metrics-wrapper :as metrics-lib])
-  (:import [io.dropwizard.metrics5 Meter])
   (:gen-class
     :name tech.gojek.ziggurat.internal.Metrics
     :methods [^{:static true} [incrementCount [String String] void]

--- a/test/ziggurat/dropwizard_metrics_wrapper_test.clj
+++ b/test/ziggurat/dropwizard_metrics_wrapper_test.clj
@@ -48,11 +48,15 @@
 (deftest initialize-test
   (let [statsd-config {:host "localhost" :port 8125 :enabled true}]
     (testing "It initializes the metrics transport and reporter and returns a map when enabled"
-      (let [{:keys [transport reporter]} (dw-metrics/initialize statsd-config)]
+      (let [_ (dw-metrics/initialize statsd-config)
+            {:keys [transport reporter]} @dw-metrics/reporter-and-transport-state]
         (is (instance? UdpTransport transport))
-        (is (instance? DatadogReporter reporter))))
+        (is (instance? DatadogReporter reporter))
+        (dw-metrics/terminate)))
     (testing "It does not initialize the transport and reporter when disabled"
       (let [statsd-config (assoc statsd-config :enabled false)
-            result (dw-metrics/initialize statsd-config)]
-        (is (nil? result))))))
+            _ (dw-metrics/initialize statsd-config)
+            result @dw-metrics/reporter-and-transport-state]
+        (is (nil? result))
+        (dw-metrics/terminate)))))
 

--- a/test/ziggurat/dropwizard_metrics_wrapper_test.clj
+++ b/test/ziggurat/dropwizard_metrics_wrapper_test.clj
@@ -1,5 +1,5 @@
-(ns ziggurat.dropwizard-metric-wrapper-test
-  (:require [ziggurat.dropwizard-metrics-wrapper :refer :all]
+(ns ziggurat.dropwizard-metrics-wrapper-test
+  (:require [ziggurat.dropwizard-metrics-wrapper :refer :all :as dw-metrics]
             [ziggurat.config :refer [ziggurat-config]]
             [clojure.test :refer :all]
             [clojure.walk :refer [stringify-keys]])
@@ -11,15 +11,15 @@
         metric       "metric1"
         service-name (:app-name (ziggurat-config))]
     (testing "returns a meter"
-      (let [expected-tags {"actor" service-name}]
-        (with-redefs [get-tagged-metric (fn [metric-name tags]
+      (let [expected-tags {}]
+        (with-redefs [dw-metrics/get-tagged-metric (fn [metric-name tags]
                                           (is (= tags expected-tags))
                                           (.tagged metric-name tags))]
           (is (instance? Meter (mk-meter category metric))))))
     (testing "returns a meter - with additional-tags"
       (let [additional-tags {:foo "bar"}
-            expected-tags   (merge {"actor" service-name} (stringify-keys additional-tags))]
-        (with-redefs [get-tagged-metric (fn [metric-name tags]
+            expected-tags   (stringify-keys additional-tags)]
+        (with-redefs [dw-metrics/get-tagged-metric (fn [metric-name tags]
                                           (is (= tags expected-tags))
                                           (.tagged metric-name tags))]
           (is (instance? Meter (mk-meter category metric additional-tags))))))))
@@ -29,15 +29,15 @@
         metric       "metric2"
         service-name (:app-name (ziggurat-config))]
     (testing "returns a histogram"
-      (let [expected-tags {"actor" service-name}]
-        (with-redefs [get-tagged-metric (fn [metric-name tags]
+      (let [expected-tags {}]
+        (with-redefs [dw-metrics/get-tagged-metric (fn [metric-name tags]
                                                   (is (= tags expected-tags))
                                                   (.tagged metric-name tags))]
           (is (instance? Histogram (mk-histogram category metric))))))
     (testing "returns a histogram - with additional-tags"
       (let [additional-tags {:foo "bar"}
-            expected-tags   (merge {"actor" service-name} (stringify-keys additional-tags))]
-        (with-redefs [get-tagged-metric (fn [metric-name tags]
+            expected-tags   (stringify-keys additional-tags)]
+        (with-redefs [dw-metrics/get-tagged-metric (fn [metric-name tags]
                                                   (is (= tags expected-tags))
                                                   (.tagged metric-name tags))]
           (is (instance? Histogram (mk-histogram category metric additional-tags))))))))

--- a/test/ziggurat/dropwizard_metrics_wrapper_test.clj
+++ b/test/ziggurat/dropwizard_metrics_wrapper_test.clj
@@ -3,30 +3,35 @@
             [ziggurat.config :refer [ziggurat-config]]
             [clojure.test :refer :all]
             [clojure.walk :refer [stringify-keys]])
-  (:import [io.dropwizard.metrics5 Meter Histogram]))
+  (:import [io.dropwizard.metrics5 Meter Histogram]
+           (com.gojek.metrics.datadog DatadogReporter)
+           (com.gojek.metrics.datadog.transport UdpTransport)))
 
 (deftest mk-meter-test
   (let [category     "category"
         metric       "metric1"
-        service-name (:app-name (ziggurat-config))]
-    (testing "returns a meter"
+        service-name (:app-name (ziggurat-config))
+        tags         {:actor service-name
+                      :foo   "bar"}]
+    (testing "returns a meter with no tags when none are passed to it"
       (let [expected-tags {}]
         (with-redefs [dw-metrics/get-tagged-metric (fn [metric-name tags]
                                                      (is (= tags expected-tags))
                                                      (.tagged metric-name tags))]
           (is (instance? Meter (mk-meter category metric))))))
-    (testing "returns a meter - with additional-tags"
-      (let [additional-tags {:foo "bar"}
-            expected-tags   (stringify-keys additional-tags)]
+    (testing "returns a meter - with tags with stringified keys"
+      (let [expected-tags (stringify-keys tags)]
         (with-redefs [dw-metrics/get-tagged-metric (fn [metric-name tags]
                                                      (is (= tags expected-tags))
                                                      (.tagged metric-name tags))]
-          (is (instance? Meter (mk-meter category metric additional-tags))))))))
+          (is (instance? Meter (mk-meter category metric tags))))))))
 
 (deftest mk-histogram-test
   (let [category     "category"
         metric       "metric2"
-        service-name (:app-name (ziggurat-config))]
+        service-name (:app-name (ziggurat-config))
+        tags         {:actor service-name
+                      :foo   "bar"}]
     (testing "returns a histogram"
       (let [expected-tags {}]
         (with-redefs [dw-metrics/get-tagged-metric (fn [metric-name tags]
@@ -34,10 +39,20 @@
                                                      (.tagged metric-name tags))]
           (is (instance? Histogram (mk-histogram category metric))))))
     (testing "returns a histogram - with additional-tags"
-      (let [additional-tags {:foo "bar"}
-            expected-tags   (stringify-keys additional-tags)]
+      (let [expected-tags (stringify-keys tags)]
         (with-redefs [dw-metrics/get-tagged-metric (fn [metric-name tags]
                                                      (is (= tags expected-tags))
                                                      (.tagged metric-name tags))]
-          (is (instance? Histogram (mk-histogram category metric additional-tags))))))))
+          (is (instance? Histogram (mk-histogram category metric tags))))))))
+
+(deftest initialize-test
+  (let [statsd-config {:host "localhost" :port 8125 :enabled true}]
+    (testing "It initializes the metrics transport and reporter and returns a map when enabled"
+      (let [{:keys [transport reporter]} (dw-metrics/initialize statsd-config)]
+        (is (instance? UdpTransport transport))
+        (is (instance? DatadogReporter reporter))))
+    (testing "It does not initialize the transport and reporter when disabled"
+      (let [statsd-config (assoc statsd-config :enabled false)
+            result (dw-metrics/initialize statsd-config)]
+        (is (nil? result))))))
 

--- a/test/ziggurat/dropwizard_metrics_wrapper_test.clj
+++ b/test/ziggurat/dropwizard_metrics_wrapper_test.clj
@@ -5,7 +5,6 @@
             [clojure.walk :refer [stringify-keys]])
   (:import [io.dropwizard.metrics5 Meter Histogram]))
 
-
 (deftest mk-meter-test
   (let [category     "category"
         metric       "metric1"
@@ -13,15 +12,15 @@
     (testing "returns a meter"
       (let [expected-tags {}]
         (with-redefs [dw-metrics/get-tagged-metric (fn [metric-name tags]
-                                          (is (= tags expected-tags))
-                                          (.tagged metric-name tags))]
+                                                     (is (= tags expected-tags))
+                                                     (.tagged metric-name tags))]
           (is (instance? Meter (mk-meter category metric))))))
     (testing "returns a meter - with additional-tags"
       (let [additional-tags {:foo "bar"}
             expected-tags   (stringify-keys additional-tags)]
         (with-redefs [dw-metrics/get-tagged-metric (fn [metric-name tags]
-                                          (is (= tags expected-tags))
-                                          (.tagged metric-name tags))]
+                                                     (is (= tags expected-tags))
+                                                     (.tagged metric-name tags))]
           (is (instance? Meter (mk-meter category metric additional-tags))))))))
 
 (deftest mk-histogram-test
@@ -31,14 +30,14 @@
     (testing "returns a histogram"
       (let [expected-tags {}]
         (with-redefs [dw-metrics/get-tagged-metric (fn [metric-name tags]
-                                                  (is (= tags expected-tags))
-                                                  (.tagged metric-name tags))]
+                                                     (is (= tags expected-tags))
+                                                     (.tagged metric-name tags))]
           (is (instance? Histogram (mk-histogram category metric))))))
     (testing "returns a histogram - with additional-tags"
       (let [additional-tags {:foo "bar"}
             expected-tags   (stringify-keys additional-tags)]
         (with-redefs [dw-metrics/get-tagged-metric (fn [metric-name tags]
-                                                  (is (= tags expected-tags))
-                                                  (.tagged metric-name tags))]
+                                                     (is (= tags expected-tags))
+                                                     (.tagged metric-name tags))]
           (is (instance? Histogram (mk-histogram category metric additional-tags))))))))
 

--- a/test/ziggurat/metrics_test.clj
+++ b/test/ziggurat/metrics_test.clj
@@ -24,10 +24,10 @@
             meter                     (Meter.)
             expected-additional-tags  default-tags]
         (with-redefs [dw-metrics/mk-meter (fn [metric-namespaces metric additional-tags]
-                                         (is (= additional-tags expected-additional-tags))
-                                         (reset! mk-meter-args {:metric-namespaces metric-namespaces
-                                                                :metric           metric})
-                                         meter)]
+                                            (is (= additional-tags expected-additional-tags))
+                                            (reset! mk-meter-args {:metric-namespaces metric-namespaces
+                                                                   :metric           metric})
+                                            meter)]
           (metrics/increment-count expected-metric-namespaces metric expected-n input-additional-tags)
           (is (= expected-n (.getCount meter)))
           (is (= (metrics/intercalate-dot expected-metric-namespaces) (:metric-namespaces @mk-meter-args)))
@@ -38,10 +38,10 @@
             meter                     (Meter.)
             expected-additional-tags  default-tags]
         (with-redefs [dw-metrics/mk-meter (fn [metric-namespace metric additional-tags]
-                                         (is (= additional-tags expected-additional-tags))
-                                         (reset! mk-meter-args {:metric-namespace metric-namespace
-                                                                :metric           metric})
-                                         meter)]
+                                            (is (= additional-tags expected-additional-tags))
+                                            (reset! mk-meter-args {:metric-namespace metric-namespace
+                                                                   :metric           metric})
+                                            meter)]
           (metrics/increment-count expected-metric-namespace metric expected-n)
           (is (= expected-n (.getCount meter)))
           (is (= (metrics/intercalate-dot expected-metric-namespace) (:metric-namespace @mk-meter-args)))
@@ -52,10 +52,10 @@
             meter                     (Meter.)
             expected-additional-tags  default-tags]
         (with-redefs [dw-metrics/mk-meter (fn [metric-namespace metric additional-tags]
-                                         (is (= additional-tags expected-additional-tags))
-                                         (reset! mk-meter-args {:metric-namespace metric-namespace
-                                                                :metric           metric})
-                                         meter)]
+                                            (is (= additional-tags expected-additional-tags))
+                                            (reset! mk-meter-args {:metric-namespace metric-namespace
+                                                                   :metric           metric})
+                                            meter)]
           (metrics/increment-count expected-metric-namespace metric expected-additional-tags)
           (is (= expected-n (.getCount meter)))
           (is (= (metrics/intercalate-dot expected-metric-namespace) (:metric-namespace @mk-meter-args)))
@@ -68,12 +68,12 @@
             expected-additional-tags   (merge input-additional-tags default-tags)
             expected-n                 2]
         (with-redefs [dw-metrics/mk-meter (fn [metric-namespaces metric additional-tags]
-                                         (is (or (and (= metric-namespaces expected-metric-namespaces) (= 0 (.getCount meter)))
-                                                 (and (= metric-namespaces actor-prefixed-metric-ns) (= 1 (.getCount meter)))))
-                                         (is (= additional-tags expected-additional-tags))
-                                         (reset! mk-meter-args {:metric-namespaces metric-namespaces
-                                                                :metric            metric})
-                                         meter)]
+                                            (is (or (and (= metric-namespaces expected-metric-namespaces) (= 0 (.getCount meter)))
+                                                    (and (= metric-namespaces actor-prefixed-metric-ns) (= 1 (.getCount meter)))))
+                                            (is (= additional-tags expected-additional-tags))
+                                            (reset! mk-meter-args {:metric-namespaces metric-namespaces
+                                                                   :metric            metric})
+                                            meter)]
           (metrics/increment-count expected-metric-namespaces metric 1 input-additional-tags)
           (is (= expected-n (.getCount meter)))
           (is (= actor-prefixed-metric-ns (:metric-namespaces @mk-meter-args)))
@@ -84,10 +84,10 @@
             meter                     (Meter.)
             expected-additional-tags  default-tags]
         (with-redefs [dw-metrics/mk-meter (fn [metric-namespaces metric additional-tags]
-                                         (is (= additional-tags expected-additional-tags))
-                                         (reset! mk-meter-args {:metric-namespace metric-namespaces
-                                                                :metric           metric})
-                                         meter)]
+                                            (is (= additional-tags expected-additional-tags))
+                                            (reset! mk-meter-args {:metric-namespace metric-namespaces
+                                                                   :metric           metric})
+                                            meter)]
           (metrics/increment-count expected-metric-namespaces metric)
           (is (= expected-n (.getCount meter)))
           (is (= (metrics/intercalate-dot expected-metric-namespaces) (:metric-namespace @mk-meter-args)))
@@ -100,12 +100,12 @@
             expected-additional-tags  default-tags
             expected-n                2]
         (with-redefs [dw-metrics/mk-meter (fn [metric-namespace metric additional-tags]
-                                         (is (or (and (= metric-namespace expected-metric-namespace) (= 0 (.getCount meter)))
-                                                 (and (= metric-namespace actor-prefixed-metric-ns) (= 1 (.getCount meter)))))
-                                         (is (= additional-tags expected-additional-tags))
-                                         (reset! mk-meter-args {:metric-namespace metric-namespace
-                                                                :metric           metric})
-                                         meter)]
+                                            (is (or (and (= metric-namespace expected-metric-namespace) (= 0 (.getCount meter)))
+                                                    (and (= metric-namespace actor-prefixed-metric-ns) (= 1 (.getCount meter)))))
+                                            (is (= additional-tags expected-additional-tags))
+                                            (reset! mk-meter-args {:metric-namespace metric-namespace
+                                                                   :metric           metric})
+                                            meter)]
           (metrics/increment-count expected-metric-namespace metric 1 nil)
           (is (= expected-n (.getCount meter)))
           (is (= actor-prefixed-metric-ns (:metric-namespace @mk-meter-args)))
@@ -146,10 +146,10 @@
             meter                      (Meter.)
             _                          (.mark meter expected-n)]
         (with-redefs [dw-metrics/mk-meter (fn [metric-namespaces metric additional-tags]
-                                         (is (= additional-tags expected-additional-tags))
-                                         (reset! mk-meter-args {:metric-namespaces metric-namespaces
-                                                                :metric           metric})
-                                         meter)]
+                                            (is (= additional-tags expected-additional-tags))
+                                            (reset! mk-meter-args {:metric-namespaces metric-namespaces
+                                                                   :metric           metric})
+                                            meter)]
           (is (= expected-n (.getCount meter)))
           (metrics/decrement-count expected-metric-namespaces metric expected-n input-additional-tags)
           (is (zero? (.getCount meter)))
@@ -163,12 +163,12 @@
             meter                      (Meter.)
             _                          (.mark meter expected-n)]
         (with-redefs [dw-metrics/mk-meter (fn [metric-namespaces metric additional-tags]
-                                         (is (= additional-tags expected-additional-tags))
-                                         (is (or (and (= metric-namespaces expected-metric-namespaces) (= 2 (.getCount meter)))
-                                                 (and (= metric-namespaces actor-prefixed-metric-ns) (= 1 (.getCount meter)))))
-                                         (reset! mk-meter-args {:metric-namespaces metric-namespaces
-                                                                :metric            metric})
-                                         meter)]
+                                            (is (= additional-tags expected-additional-tags))
+                                            (is (or (and (= metric-namespaces expected-metric-namespaces) (= 2 (.getCount meter)))
+                                                    (and (= metric-namespaces actor-prefixed-metric-ns) (= 1 (.getCount meter)))))
+                                            (reset! mk-meter-args {:metric-namespaces metric-namespaces
+                                                                   :metric            metric})
+                                            meter)]
           (is (= expected-n (.getCount meter)))
           (metrics/decrement-count expected-metric-namespaces metric 1 input-additional-tags)
           (is (zero? (.getCount meter)))
@@ -180,10 +180,10 @@
             meter                      (Meter.)
             _                          (.mark meter expected-n)]
         (with-redefs [dw-metrics/mk-meter (fn [metric-namespaces metric additional-tags]
-                                         (is (= additional-tags expected-additional-tags))
-                                         (reset! mk-meter-args {:metric-namespaces metric-namespaces
-                                                                :metric            metric})
-                                         meter)]
+                                            (is (= additional-tags expected-additional-tags))
+                                            (reset! mk-meter-args {:metric-namespaces metric-namespaces
+                                                                   :metric            metric})
+                                            meter)]
           (is (= expected-n (.getCount meter)))
           (metrics/decrement-count expected-metric-namespaces metric expected-n input-additional-tags)
           (is (zero? (.getCount meter)))
@@ -197,12 +197,12 @@
             meter                     (Meter.)
             _                         (.mark meter expected-n)]
         (with-redefs [dw-metrics/mk-meter (fn [metric-namespace metric additional-tags]
-                                         (is (= additional-tags expected-additional-tags))
-                                         (is (or (and (= metric-namespace expected-metric-namespace) (= 2 (.getCount meter)))
-                                                 (and (= metric-namespace actor-prefixed-metric-ns) (= 1 (.getCount meter)))))
-                                         (reset! mk-meter-args {:metric-namespace metric-namespace
-                                                                :metric           metric})
-                                         meter)]
+                                            (is (= additional-tags expected-additional-tags))
+                                            (is (or (and (= metric-namespace expected-metric-namespace) (= 2 (.getCount meter)))
+                                                    (and (= metric-namespace actor-prefixed-metric-ns) (= 1 (.getCount meter)))))
+                                            (reset! mk-meter-args {:metric-namespace metric-namespace
+                                                                   :metric           metric})
+                                            meter)]
           (is (= expected-n (.getCount meter)))
           (metrics/decrement-count expected-metric-namespace metric 1 nil)
           (is (zero? (.getCount meter)))
@@ -242,10 +242,10 @@
             histogram                 (Histogram. reservoir)
             expected-additional-tags  default-tags]
         (with-redefs [dw-metrics/mk-histogram (fn [metric-namespace metric additional-tags]
-                                             (is (= additional-tags expected-additional-tags))
-                                             (reset! mk-histogram-args {:metric-namespace metric-namespace
-                                                                        :metric           metric})
-                                             histogram)]
+                                                (is (= additional-tags expected-additional-tags))
+                                                (reset! mk-histogram-args {:metric-namespace metric-namespace
+                                                                           :metric           metric})
+                                                histogram)]
           (metrics/report-histogram expected-metric-namespace time-val input-additional-tags)
           (is (= 1 (.getCount histogram)))
           (is (= (metrics/intercalate-dot expected-metric-namespace) (:metric-namespace @mk-histogram-args)))
@@ -259,12 +259,12 @@
             expected-additional-tags   (merge default-tags input-additional-tags)
             expected-n                 2]
         (with-redefs [dw-metrics/mk-histogram (fn [metric-namespaces metric additional-tags]
-                                             (is (= additional-tags expected-additional-tags))
-                                             (is (or (and (= metric-namespaces expected-metric-namespaces) (= 0 (.getCount histogram)))
-                                                     (and (= metric-namespaces actor-prefixed-metric-ns) (= 1 (.getCount histogram)))))
-                                             (reset! mk-histogram-args {:metric-namespaces metric-namespaces
-                                                                        :metric            metric})
-                                             histogram)]
+                                                (is (= additional-tags expected-additional-tags))
+                                                (is (or (and (= metric-namespaces expected-metric-namespaces) (= 0 (.getCount histogram)))
+                                                        (and (= metric-namespaces actor-prefixed-metric-ns) (= 1 (.getCount histogram)))))
+                                                (reset! mk-histogram-args {:metric-namespaces metric-namespaces
+                                                                           :metric            metric})
+                                                histogram)]
           (metrics/report-histogram expected-metric-namespaces time-val input-additional-tags)
           (is (= expected-n (.getCount histogram)))
           (is (= actor-prefixed-metric-ns (:metric-namespaces @mk-histogram-args)))
@@ -278,12 +278,12 @@
             expected-additional-tags  default-tags
             expected-n                2]
         (with-redefs [dw-metrics/mk-histogram (fn [metric-namespace metric additional-tags]
-                                             (is (= additional-tags expected-additional-tags))
-                                             (is (or (and (= metric-namespace expected-metric-namespace) (= 0 (.getCount histogram)))
-                                                     (and (= metric-namespace actor-prefixed-metric-ns) (= 1 (.getCount histogram)))))
-                                             (reset! mk-histogram-args {:metric-namespace metric-namespace
-                                                                        :metric           metric})
-                                             histogram)]
+                                                (is (= additional-tags expected-additional-tags))
+                                                (is (or (and (= metric-namespace expected-metric-namespace) (= 0 (.getCount histogram)))
+                                                        (and (= metric-namespace actor-prefixed-metric-ns) (= 1 (.getCount histogram)))))
+                                                (reset! mk-histogram-args {:metric-namespace metric-namespace
+                                                                           :metric           metric})
+                                                histogram)]
           (metrics/report-histogram expected-metric-namespace time-val)
           (is (= expected-n (.getCount histogram)))
           (is (= actor-prefixed-metric-ns (:metric-namespace @mk-histogram-args)))

--- a/test/ziggurat/metrics_test.clj
+++ b/test/ziggurat/metrics_test.clj
@@ -132,10 +132,10 @@
                                                   (is (= value expected-n)))]
           (metrics/decrement-count expected-metric-namespaces passed-metric-name expected-n input-tags))))
     (testing "calls metrics library update-counter with the correct args - string as an argument"
-      (let [expected-tags   (merge default-tags input-tags)
-            metric-namespace "metric-ns"
-            actor-prefixed-metric-ns   (str (:app-name (ziggurat-config)) "." metric-namespace)
-            metric-namespaces-called     (atom [])]
+      (let [expected-tags            (merge default-tags input-tags)
+            metric-namespace         "metric-ns"
+            actor-prefixed-metric-ns (str (:app-name (ziggurat-config)) "." metric-namespace)
+            metric-namespaces-called (atom [])]
         (with-redefs [dw-metrics/update-counter (fn [namespace metric tags sign value]
                                                   (cond (= namespace metric-namespace) (swap! metric-namespaces-called conj namespace)
                                                         (= namespace actor-prefixed-metric-ns) (swap! metric-namespaces-called conj namespace))
@@ -147,10 +147,10 @@
           (is (some #{metric-namespace} @metric-namespaces-called))
           (is (some #{actor-prefixed-metric-ns} @metric-namespaces-called)))))
     (testing "calls metrics library update-counter with the correct args - without topic name on the namespace"
-      (let [expected-additional-tags   (merge default-tags input-tags)
-            metric-namespaces ["metric" "ns"]
-            expected-namespace "metric.ns"
-            expected-tags     (merge default-tags input-tags)]
+      (let [expected-additional-tags (merge default-tags input-tags)
+            metric-namespaces        ["metric" "ns"]
+            expected-namespace       "metric.ns"
+            expected-tags            (merge default-tags input-tags)]
         (with-redefs [dw-metrics/update-counter (fn [namespace metric tags sign value]
                                                   (is (= namespace expected-namespace))
                                                   (is (= metric passed-metric-name))
@@ -159,10 +159,10 @@
                                                   (is (= value expected-n)))]
           (metrics/decrement-count metric-namespaces passed-metric-name expected-n input-tags))))
     (testing "calls metrics library update-counter with the correct args - additional-tags is nil"
-      (let [expected-tags  default-tags
-            metric-namespace "metric-ns"
-            actor-prefixed-metric-ns  (str (:app-name (ziggurat-config)) "." metric-namespace)
-            metric-namespaces-called  (atom [])]
+      (let [expected-tags            default-tags
+            metric-namespace         "metric-ns"
+            actor-prefixed-metric-ns (str (:app-name (ziggurat-config)) "." metric-namespace)
+            metric-namespaces-called (atom [])]
         (with-redefs [dw-metrics/update-counter (fn [namespace metric tags sign value]
                                                   (cond (= namespace metric-namespace) (swap! metric-namespaces-called conj namespace)
                                                         (= namespace actor-prefixed-metric-ns) (swap! metric-namespaces-called conj namespace))
@@ -182,12 +182,12 @@
                                                   (reset! decrement-count-called? true)))]
           (metrics/-decrementCount metric-namespace passed-metric-name)
           (is (true? @decrement-count-called?))))
-      (let [tags          (doto (java.util.HashMap.)
-                            (.put ":foo" "bar")
-                            (.put ":bar" "foo"))
-            expected-tags {:foo "bar" :bar "foo"}
-            decrement-count-called?  (atom false)
-            metric-namespace         "namespace"]
+      (let [tags                    (doto (java.util.HashMap.)
+                                      (.put ":foo" "bar")
+                                      (.put ":bar" "foo"))
+            expected-tags           {:foo "bar" :bar "foo"}
+            decrement-count-called? (atom false)
+            metric-namespace        "namespace"]
         (with-redefs [metrics/decrement-count (fn [actual-namespace actual-metric actual-additional-tags]
                                                 (if (and (= actual-namespace metric-namespace)
                                                          (= actual-metric passed-metric-name)
@@ -197,141 +197,121 @@
           (is (true? @decrement-count-called?)))))))
 
 (deftest report-histogram-test
-  (let [expected-topic-entity-name "expected-topic-entity-name"
-        input-additional-tags      {:topic_name expected-topic-entity-name}
-        time-val                   10]
-    (testing "updates time-val - vector as an argument"
-      (let [expected-metric-namespace [expected-topic-entity-name "message-received-delay-histogram"]
-            mk-histogram-args         (atom nil)
-            reservoir                 (UniformReservoir.)
-            histogram                 (Histogram. reservoir)
-            expected-additional-tags  default-tags]
-        (with-redefs [dw-metrics/mk-histogram (fn [metric-namespace metric additional-tags]
-                                                (is (= additional-tags expected-additional-tags))
-                                                (reset! mk-histogram-args {:metric-namespace metric-namespace
-                                                                           :metric           metric})
-                                                histogram)]
-          (metrics/report-histogram expected-metric-namespace time-val input-additional-tags)
-          (is (= 1 (.getCount histogram)))
-          (is (= (metrics/intercalate-dot expected-metric-namespace) (:metric-namespace @mk-histogram-args)))
-          (is (= "all" (:metric @mk-histogram-args))))))
-    (testing "updates time-val - string as an argument"
-      (let [expected-metric-namespaces "message-received-delay-histogram"
-            actor-prefixed-metric-ns   (str (:app-name (ziggurat-config)) "." expected-metric-namespaces)
-            mk-histogram-args          (atom nil)
-            reservoir                  (UniformReservoir.)
-            histogram                  (Histogram. reservoir)
-            expected-additional-tags   (merge default-tags input-additional-tags)
-            expected-n                 2]
-        (with-redefs [dw-metrics/mk-histogram (fn [metric-namespaces metric additional-tags]
-                                                (is (= additional-tags expected-additional-tags))
-                                                (is (or (and (= metric-namespaces expected-metric-namespaces) (= 0 (.getCount histogram)))
-                                                        (and (= metric-namespaces actor-prefixed-metric-ns) (= 1 (.getCount histogram)))))
-                                                (reset! mk-histogram-args {:metric-namespaces metric-namespaces
-                                                                           :metric            metric})
-                                                histogram)]
-          (metrics/report-histogram expected-metric-namespaces time-val input-additional-tags)
-          (is (= expected-n (.getCount histogram)))
-          (is (= actor-prefixed-metric-ns (:metric-namespaces @mk-histogram-args)))
-          (is (= "all" (:metric @mk-histogram-args))))))
-    (testing "updates time-val - w/o additional-tags argument"
-      (let [expected-metric-namespace "message-received-delay-histogram"
-            mk-histogram-args         (atom nil)
-            actor-prefixed-metric-ns  (str (:app-name (ziggurat-config)) "." expected-metric-namespace)
-            reservoir                 (UniformReservoir.)
-            histogram                 (Histogram. reservoir)
-            expected-additional-tags  default-tags
-            expected-n                2]
-        (with-redefs [dw-metrics/mk-histogram (fn [metric-namespace metric additional-tags]
-                                                (is (= additional-tags expected-additional-tags))
-                                                (is (or (and (= metric-namespace expected-metric-namespace) (= 0 (.getCount histogram)))
-                                                        (and (= metric-namespace actor-prefixed-metric-ns) (= 1 (.getCount histogram)))))
-                                                (reset! mk-histogram-args {:metric-namespace metric-namespace
-                                                                           :metric           metric})
-                                                histogram)]
-          (metrics/report-histogram expected-metric-namespace time-val)
-          (is (= expected-n (.getCount histogram)))
-          (is (= actor-prefixed-metric-ns (:metric-namespace @mk-histogram-args)))
-          (is (= "all" (:metric @mk-histogram-args)))))))
-  (testing "report time java function passes the correct parameters to report time"
-    (let [expected-metric-namespace "namespace"
-          expected-time-val         123
-          report-histogram-called?  (atom false)]
-      (with-redefs [metrics/report-histogram (fn [actual-metric-namespace actual-time-val]
-                                               (if (and (= actual-metric-namespace expected-metric-namespace)
-                                                        (= actual-time-val expected-time-val))
-                                                 (reset! report-histogram-called? true)))]
-        (metrics/-reportTime expected-metric-namespace expected-time-val)
-        (is (true? @report-histogram-called?))))
-    (let [expected-metric-namespace "namespace"
-          expected-time-val         123
-          additional-tags           (doto (java.util.HashMap.)
-                                      (.put ":foo" "bar")
-                                      (.put ":bar" "foo"))
-          expected-additional-tags  {:foo "bar" :bar "foo"}
-          report-histogram-called?  (atom false)]
-      (with-redefs [metrics/report-histogram (fn [actual-metric-namespace actual-time-val actual-additional-tags]
-                                               (is (= actual-additional-tags expected-additional-tags))
-                                               (if (and (= actual-metric-namespace expected-metric-namespace)
-                                                        (= actual-time-val expected-time-val)
-                                                        (= actual-additional-tags expected-additional-tags))
-                                                 (reset! report-histogram-called? true)))]
-        (metrics/-reportTime expected-metric-namespace expected-time-val additional-tags)
-        (is (true? @report-histogram-called?))))))
+  (let [topic-entity-name "expected-topic-entity-name"
+        input-tags        {:topic_name topic-entity-name}
+        time-val          10]
+    (testing "calls update-histogram with the correct arguments - vector as an argument"
+      (let [metric-namespaces         [topic-entity-name "message-received-delay-histogram"]
+            expected-metric-namespace (str topic-entity-name ".message-received-delay-histogram")
+            expected-tags             default-tags]
+        (with-redefs [dw-metrics/update-histogram (fn [namespace tags value]
+                                                    (is (= namespace expected-metric-namespace))
+                                                    (is (= tags expected-tags))
+                                                    (is (= value time-val)))]
+          (metrics/report-histogram metric-namespaces time-val input-tags))))
+    (testing "calls update-histogram with the correct arguments - string as an argument"
+      (let [metric-namespace         "message-received-delay-histogram"
+            actor-prefixed-metric-ns (str (:app-name (ziggurat-config)) "." metric-namespace)
+            expected-tags            (merge default-tags input-tags)
+            metric-namespaces-called (atom [])]
+        (with-redefs [dw-metrics/update-histogram (fn [namespace tags value]
+                                                    (cond (= namespace metric-namespace) (swap! metric-namespaces-called conj namespace)
+                                                          (= namespace actor-prefixed-metric-ns) (swap! metric-namespaces-called conj namespace))
+                                                    (is (= tags expected-tags))
+                                                    (is (= value time-val)))]
+          (metrics/report-histogram metric-namespace time-val input-tags)
+          (is (some #{metric-namespace} @metric-namespaces-called))
+          (is (some #{actor-prefixed-metric-ns} @metric-namespaces-called)))))
+    (testing "calls update-histogram with the correct arguments - w/o additional-tags argument"
+      (let [metric-namespace         "message-received-delay-histogram"
+            actor-prefixed-metric-ns (str (:app-name (ziggurat-config)) "." metric-namespace)
+            expected-tags            default-tags
+            metric-namespaces-called (atom [])]
+        (with-redefs [dw-metrics/update-histogram (fn [namespace tags value]
+                                                    (cond (= namespace metric-namespace) (swap! metric-namespaces-called conj namespace)
+                                                          (= namespace actor-prefixed-metric-ns) (swap! metric-namespaces-called conj namespace))
+                                                    (is (= tags expected-tags))
+                                                    (is (= value time-val)))]
+          (metrics/report-histogram metric-namespace time-val)
+          (is (some #{metric-namespace} @metric-namespaces-called))
+          (is (some #{actor-prefixed-metric-ns} @metric-namespaces-called)))))
+    (testing "report time java function passes the correct parameters to report time"
+      (let [metric-namespace         "namespace"
+            report-histogram-called? (atom false)]
+        (with-redefs [metrics/report-histogram (fn [actual-metric-namespace actual-time-val]
+                                                 (if (and (= actual-metric-namespace metric-namespace)
+                                                          (= actual-time-val time-val))
+                                                   (reset! report-histogram-called? true)))]
+          (metrics/-reportTime metric-namespace time-val)
+          (is (true? @report-histogram-called?))))
+      (let [metric-namespace         "namespace"
+            tags                     (doto (java.util.HashMap.)
+                                       (.put ":foo" "bar")
+                                       (.put ":bar" "foo"))
+            expected-tags            {:foo "bar" :bar "foo"}
+            report-histogram-called? (atom false)]
+        (with-redefs [metrics/report-histogram (fn [actual-metric-namespace actual-time-val actual-additional-tags]
+                                                 (is (= actual-additional-tags expected-tags))
+                                                 (if (and (= actual-metric-namespace metric-namespace)
+                                                          (= actual-time-val time-val)
+                                                          (= actual-additional-tags expected-tags))
+                                                   (reset! report-histogram-called? true)))]
+          (metrics/-reportTime metric-namespace time-val tags)
+          (is (true? @report-histogram-called?)))))))
 
 (deftest report-time-test
   (let [metric-namespace "metric-namespace"
         value            12
-        additional-tags  {:foo "bar"}]
+        tags             {:foo "bar"}]
     (testing "report time passes the correct metric-namespace and values to report-histogram and logs deprecation notice"
       (with-redefs [metrics/report-histogram (fn [received-metric-ns received-val]
                                                (is (= metric-namespace received-metric-ns))
                                                (is (= value received-val)))]
         (metrics/report-time metric-namespace value)))
     (testing "report time passes the correct namespace, val and addition-tags to report-histogram and logs deprecation notice"
-      (with-redefs [metrics/report-histogram (fn [received-metric-ns received-val received-additional-tags]
+      (with-redefs [metrics/report-histogram (fn [received-metric-ns received-val received-tags]
                                                (is (= metric-namespace received-metric-ns))
                                                (is (= value received-val))
-                                               (is (= additional-tags received-additional-tags)))]
-        (metrics/report-time metric-namespace value additional-tags)))))
+                                               (is (= tags received-tags)))]
+        (metrics/report-time metric-namespace value tags)))))
 
 (deftest multi-ns-report-time-test
   (testing "calls multi-ns-report-histogram with the correct arguments"
-    (let [namespaces      [["multi" "ns" "test"] ["multi-ns"]]
-          time-val        123
-          additional-tags {:foo "bar"}]
-      (with-redefs [metrics/multi-ns-report-histogram (fn [received-nss received-time-val received-additional-tags]
+    (let [namespaces [["multi" "ns" "test"] ["multi-ns"]]
+          time-val   123
+          tags       {:foo "bar"}]
+      (with-redefs [metrics/multi-ns-report-histogram (fn [received-nss received-time-val received-tags]
                                                         (is (= received-nss namespaces))
                                                         (is (= received-time-val time-val))
-                                                        (is (= received-additional-tags additional-tags)))]
-        (metrics/multi-ns-report-time namespaces time-val additional-tags)))))
+                                                        (is (= received-tags tags)))]
+        (metrics/multi-ns-report-time namespaces time-val tags)))))
 
 (deftest multi-ns-increment-count-test
   (testing "multi-ns-increment-count calls increment-count for every namespace list passed"
     (let [metric-namespaces-list               [["test" "multi" "ns"] ["test-ns"]]
           expected-metric                      "test-metric"
-          expected-additional-tags             (merge default-tags {:foo "bar"})
+          expected-tags                        (merge default-tags {:foo "bar"})
           increment-count-call-counts          (atom 0)
           expected-increment-count-call-counts 2]
-      (with-redefs [metrics/increment-count (fn [metric-namespaces metric additional-tags]
+      (with-redefs [metrics/increment-count (fn [metric-namespaces metric tags]
                                               (when (and (some #{metric-namespaces} metric-namespaces-list)
                                                          (= metric expected-metric)
-                                                         (= additional-tags expected-additional-tags))
+                                                         (= tags expected-tags))
                                                 (swap! increment-count-call-counts inc)))]
-        (metrics/multi-ns-increment-count metric-namespaces-list expected-metric expected-additional-tags)
+        (metrics/multi-ns-increment-count metric-namespaces-list expected-metric expected-tags)
         (is (= expected-increment-count-call-counts @increment-count-call-counts))))))
 
 (deftest multi-ns-report-histogram-test
   (testing "multi-ns-report-histogram calls report-histogram for every namespace list passed"
     (let [metric-namespaces-list                [["test" "multi" "ns"] ["test-ns"]]
           expected-metric                       "test-metric"
-          expected-additional-tags              (merge default-tags {:foo "bar"})
+          expected-tags                         (merge default-tags {:foo "bar"})
           report-histogram-call-counts          (atom 0)
           expected-report-histogram-call-counts 2]
-      (with-redefs [metrics/report-histogram (fn [metric-namespaces metric additional-tags]
+      (with-redefs [metrics/report-histogram (fn [metric-namespaces metric tags]
                                                (when (and (some #{metric-namespaces} metric-namespaces-list)
                                                           (= metric expected-metric)
-                                                          (= additional-tags expected-additional-tags))
+                                                          (= tags expected-tags))
                                                  (swap! report-histogram-call-counts inc)))]
-        (metrics/multi-ns-report-histogram metric-namespaces-list expected-metric expected-additional-tags)
+        (metrics/multi-ns-report-histogram metric-namespaces-list expected-metric expected-tags)
         (is (= expected-report-histogram-call-counts @report-histogram-call-counts))))))


### PR DESCRIPTION
Moves dropwizard-metrics out of metrics.clj.
Pulls in defstate into metrics.clj.
Attempts to make metrics.clj library agnostic.