### PR TITLE
Makes metrics implementation configurable

### DIFF
--- a/resources/config.test.edn
+++ b/resources/config.test.edn
@@ -7,7 +7,7 @@
             :statsd               {:host    "localhost"
                                    :port    [8125 :int]
                                    :enabled [false :bool]}
-            :metrics              {:implementation "ziggurat.dropwizard-metrics-wrapper/->DropwizardMetrics"}
+            :metrics              {:constructor "ziggurat.dropwizard-metrics-wrapper/->DropwizardMetrics"}
             :sentry               {:enabled                   [false :bool]
                                    :dsn                       "dummy"
                                    :worker-count              [10 :int]

--- a/resources/config.test.edn
+++ b/resources/config.test.edn
@@ -7,6 +7,7 @@
             :statsd               {:host    "localhost"
                                    :port    [8125 :int]
                                    :enabled [false :bool]}
+            :metrics              {:implementation "ziggurat.dropwizard-metrics-wrapper/->DropwizardMetrics"}
             :sentry               {:enabled                   [false :bool]
                                    :dsn                       "dummy"
                                    :worker-count              [10 :int]

--- a/src/ziggurat/clj_statsd_metrics_wrapper.clj
+++ b/src/ziggurat/clj_statsd_metrics_wrapper.clj
@@ -1,6 +1,7 @@
 (ns ziggurat.clj-statsd-metrics-wrapper
   (:require [clj-statsd :as statsd]
-            [ziggurat.metrics-interface :refer [MetricsLib]]))
+            [ziggurat.metrics-interface])
+  (:import (ziggurat.metrics_interface MetricsProtocol)))
 
 (def rate 1.0)
 
@@ -36,7 +37,7 @@
     (statsd/timing final-metric value rate final-tags)))
 
 (deftype CljStatsd []
-  MetricsLib
+  MetricsProtocol
   (initialize [this statsd-config] (initialize statsd-config))
   (terminate [this] (terminate))
   (update-counter [this namespace metric tags signed-val] (update-counter namespace metric tags signed-val))

--- a/src/ziggurat/clj_statsd_metrics_wrapper.clj
+++ b/src/ziggurat/clj_statsd_metrics_wrapper.clj
@@ -30,7 +30,7 @@
         final-metric (str namespace "." metric)]
     (statsd/increment final-metric value rate final-tags)))
 
-(defn update-histogram [namespace metric tags value]
+(defn update-timing [namespace metric tags value]
   (let [final-tags (build-tags tags)
         final-metric (str namespace "." metric)]
     (statsd/timing final-metric value rate final-tags)))
@@ -40,4 +40,4 @@
   (initialize [this statsd-config] (initialize statsd-config))
   (terminate [this] (terminate))
   (update-counter [this namespace metric tags signed-val] (update-counter namespace metric tags signed-val))
-  (update-histogram [this namespace metric tags value] (update-histogram namespace metric tags value)))
+  (update-timing [this namespace metric tags value] (update-timing namespace metric tags value)))

--- a/src/ziggurat/dropwizard_metrics_wrapper.clj
+++ b/src/ziggurat/dropwizard_metrics_wrapper.clj
@@ -75,4 +75,4 @@
   (initialize [this statsd-config] (initialize statsd-config))
   (terminate [this] (terminate))
   (update-counter [this namespace metric tags value] (update-counter namespace metric tags value))
-  (update-histogram [this namespace metric tags value] (update-histogram namespace tags value)))
+  (update-timing [this namespace metric tags value] (update-histogram namespace tags value)))

--- a/src/ziggurat/dropwizard_metrics_wrapper.clj
+++ b/src/ziggurat/dropwizard_metrics_wrapper.clj
@@ -58,7 +58,7 @@
    (let [namespace        (str category "." metric)
          metric-name      (MetricRegistry/name ^String namespace nil)
          stringified-tags (stringify-keys tags)
-         tagged-metric    (.tagged ^MetricName metric-name stringified-tags)]
+         tagged-metric    (get-tagged-metric metric-name stringified-tags)]
      (.histogram ^MetricRegistry metrics-registry ^MetricName tagged-metric))))
 
 (defn update-counter
@@ -67,8 +67,8 @@
     (.mark ^Meter meter value)))
 
 (defn update-histogram
-  [namespace tags value]
-  (let [histogram (mk-histogram namespace "all" tags)]
+  [namespace metric tags value]
+  (let [histogram (mk-histogram namespace metric tags)]
     (.update ^Histogram histogram value)))
 
 (deftype DropwizardMetrics []
@@ -76,4 +76,4 @@
   (initialize [this statsd-config] (initialize statsd-config))
   (terminate [this] (terminate))
   (update-counter [this namespace metric tags value] (update-counter namespace metric tags value))
-  (update-timing [this namespace metric tags value] (update-histogram namespace tags value)))
+  (update-timing [this namespace metric tags value] (update-histogram namespace metric tags value)))

--- a/src/ziggurat/dropwizard_metrics_wrapper.clj
+++ b/src/ziggurat/dropwizard_metrics_wrapper.clj
@@ -2,12 +2,13 @@
   (:require [clojure.tools.logging :as log]
             [ziggurat.config :refer [ziggurat-config]]
             [clojure.walk :refer [stringify-keys]]
-            [ziggurat.metrics-interface :refer [MetricsLib]])
+            [ziggurat.metrics-interface])
   (:import [com.gojek.metrics.datadog.transport UdpTransport UdpTransport$Builder]
            [io.dropwizard.metrics5 MetricRegistry]
            [com.gojek.metrics.datadog DatadogReporter]
            [java.util.concurrent TimeUnit]
-           [io.dropwizard.metrics5 Histogram Meter MetricName MetricRegistry]))
+           [io.dropwizard.metrics5 Histogram Meter MetricName MetricRegistry]
+           (ziggurat.metrics_interface MetricsProtocol)))
 
 (defonce metrics-registry
   (MetricRegistry.))
@@ -71,7 +72,7 @@
     (.update ^Histogram histogram value)))
 
 (deftype DropwizardMetrics []
-  MetricsLib
+  MetricsProtocol
   (initialize [this statsd-config] (initialize statsd-config))
   (terminate [this] (terminate))
   (update-counter [this namespace metric tags value] (update-counter namespace metric tags value))

--- a/src/ziggurat/metrics.clj
+++ b/src/ziggurat/metrics.clj
@@ -7,13 +7,13 @@
             [ziggurat.metrics-interface :as metrics-interface]
             [ziggurat.dropwizard-metrics-wrapper :refer [->DropwizardMetrics]])
   (:gen-class
-    :name tech.gojek.ziggurat.internal.Metrics
-    :methods [^{:static true} [incrementCount [String String] void]
-              ^{:static true} [incrementCount [String String java.util.Map] void]
-              ^{:static true} [decrementCount [String String] void]
-              ^{:static true} [decrementCount [String String java.util.Map] void]
-              ^{:static true} [reportTime [String long] void]
-              ^{:static true} [reportTime [String long java.util.Map] void]]))
+   :name tech.gojek.ziggurat.internal.Metrics
+   :methods [^{:static true} [incrementCount [String String] void]
+             ^{:static true} [incrementCount [String String java.util.Map] void]
+             ^{:static true} [decrementCount [String String] void]
+             ^{:static true} [decrementCount [String String java.util.Map] void]
+             ^{:static true} [reportTime [String long] void]
+             ^{:static true} [reportTime [String long java.util.Map] void]]))
 
 (def metric-impl (atom nil))
 
@@ -34,11 +34,11 @@
     (reset! metric-impl (metrics-impl-constructor))))
 
 (defstate statsd-reporter
-          :start (do (log/info "Initializing Metrics")
-                     (initialise-metrics-library)
-                     (metrics-interface/initialize @metric-impl (statsd-config)))
-          :stop (do (log/info "Terminating Metrics")
-                    (metrics-interface/terminate @metric-impl)))
+  :start (do (log/info "Initializing Metrics")
+             (initialise-metrics-library)
+             (metrics-interface/initialize @metric-impl (statsd-config)))
+  :stop (do (log/info "Terminating Metrics")
+            (metrics-interface/terminate @metric-impl)))
 
 (defn intercalate-dot
   [names]

--- a/src/ziggurat/metrics.clj
+++ b/src/ziggurat/metrics.clj
@@ -20,8 +20,8 @@
 (defn get-metrics-implementor-constructor []
   (if-let [configured-metrics-class-constructor (get-in (ziggurat-config) [:metrics :implementation])]
     (let [configured-constructor-symbol (symbol configured-metrics-class-constructor)
-          constructor-namespace         (namespace configured-constructor-symbol)
-          _                             (require [(symbol constructor-namespace)])]
+          constructor-namespace         (namespace configured-constructor-symbol)]
+      (require [(symbol constructor-namespace)])
       (resolve configured-constructor-symbol))
     ->DropwizardMetrics))
 

--- a/src/ziggurat/metrics.clj
+++ b/src/ziggurat/metrics.clj
@@ -109,9 +109,10 @@
   ([metric-namespaces val additional-tags]
    (let [intercalated-metric-namespaces (get-metric-namespaces metric-namespaces)
          tags                           (remove-topic-tag-for-old-namespace (get-all-tags additional-tags metric-namespaces) metric-namespaces)
-         integer-value                  (get-int val)]
+         integer-value                  (get-int val)
+         metric                          "all"]
      (doseq [metric-ns intercalated-metric-namespaces]
-       (metrics-interface/update-timing @metric-impl metric-ns nil tags integer-value)))))
+       (metrics-interface/update-timing @metric-impl metric-ns metric tags integer-value)))))
 
 (defn report-time
   "This function is an alias for `report-histogram`.

--- a/src/ziggurat/metrics.clj
+++ b/src/ziggurat/metrics.clj
@@ -107,7 +107,7 @@
          tags                           (remove-topic-tag-for-old-namespace (get-all-tags additional-tags metric-namespaces) metric-namespaces)
          integer-value                  (get-int val)]
      (doseq [metric-ns intercalated-metric-namespaces]
-       (metrics-interface/update-histogram @metric-impl metric-ns nil tags integer-value)))))
+       (metrics-interface/update-timing @metric-impl metric-ns nil tags integer-value)))))
 
 (defn report-time
   "This function is an alias for `report-histogram`.

--- a/src/ziggurat/metrics.clj
+++ b/src/ziggurat/metrics.clj
@@ -18,7 +18,7 @@
 (def metric-impl (atom nil))
 
 (defn- get-metrics-implementor-constructor []
-  (if-let [configured-metrics-class-constructor (get-in (ziggurat-config) [:metrics :implementation])]
+  (if-let [configured-metrics-class-constructor (get-in (ziggurat-config) [:metrics :constructor])]
     (let [configured-constructor-symbol (symbol configured-metrics-class-constructor)
           constructor-namespace         (namespace configured-constructor-symbol)
           _                             (require [(symbol constructor-namespace)])

--- a/src/ziggurat/metrics_interface.clj
+++ b/src/ziggurat/metrics_interface.clj
@@ -1,6 +1,6 @@
 (ns ziggurat.metrics-interface)
 
-(defprotocol MetricsLib
+(defprotocol MetricsProtocol
   (initialize [impl statsd-config])
   (terminate  [impl])
   (update-counter [impl namespace metric tags signed-val])

--- a/src/ziggurat/metrics_interface.clj
+++ b/src/ziggurat/metrics_interface.clj
@@ -28,7 +28,7 @@
   Args:
   - impl :  the class object that implements this protocol, i.e. an instance of the deftype for example
   - namespace : the namespace of the metric e.g. `message-processing`
-  - metric : the metric for which the value is being generated e.g. `success`, the final metric is created concatenating the namespace and the metric `namespace.metric` - `message-processing.success`
+  - metric : the metric for which the value is being generated, currently a constant metric name - `all` is being passed for all update-timing. This is due to legacy reasons. We can't change it suddenly as it will be a breaking change for current applications and they will need to change their dashboards.
   - tags : these are the tags attached to each metric. They are passed in the form of a clojure map e.g. {:topic_entity \"stream\" :actor \"application\"} which can then be converted to statsd specific tags (see `ziggurat.clj-statsd-metrics-wrapper` namespace for example)
   - value : the value which is to be reported for the timing.
   "

--- a/src/ziggurat/metrics_interface.clj
+++ b/src/ziggurat/metrics_interface.clj
@@ -4,6 +4,6 @@
   (initialize [impl statsd-config])
   (terminate  [impl])
   (update-counter [impl namespace metric tags signed-val])
-  (update-histogram [impl namespace metric tags value]))
+  (update-timing [impl namespace metric tags value]))
 
 

--- a/src/ziggurat/metrics_interface.clj
+++ b/src/ziggurat/metrics_interface.clj
@@ -1,6 +1,37 @@
 (ns ziggurat.metrics-interface)
 
 (defprotocol MetricsProtocol
+  "A protocol that defines the interface for statsd metrics implementation libraries. Any type or class that implements this protocol can be passed to the metrics namespace to be used for reporting metrics to statsd.
+  Example implementations for this protocol: ziggurat.clj-statsd-metrics-wrapper/CljStatsd, ziggurat.dropwizard-metrics-wrapper/DropwizardMetrics
+
+  initialize [impl statsd-config]
+  This is used to initialize the metrics library so that it can push metrics to the telegraf instance.
+  Args:
+    - impl : the class object that implements this protocol, i.e. an instance of the deftype for example
+    - statsd-config : the configuration required to initialize the metrics library. It is a map {:host \"localhost\" :port 8125 :enabled true}. The config map is read from the config {:ziggurat {:statsd {}}} path.
+
+  terminate [impl]
+  This is the function to ensure clean shutdown of the library and thus the application. It is called when the service is being stopped.
+  - impl : the class object that implements this protocol, i.e. an instance of the deftype for example
+
+  update-counter [impl namespace metric tags signed-val]
+  This is the function to report a [counter](https://github.com/statsd/statsd/blob/master/docs/metric_types.md#counting) to statsd.
+  Args:
+  - impl :  the class object that implements this protocol, i.e. an instance of the deftype for example
+  - namespace : the namespace of the metric e.g. `message-processing`
+  - metric : the metric for which the value is being generated e.g. `success`, the final metric is created concatenating the namespace and the metric `namespace.metric` - `message-processing.success`
+  - tags : these are the tags attached to each metric. They are passed in the form of a clojure map e.g. {:topic_entity \"stream\" :actor \"application\"} which can then be converted to statsd specific tags (see `ziggurat.clj-statsd-metrics-wrapper` namespace for example)
+  - signed-val : this is the value that the counter should be updated by. It is a signed value, so it will have a +ve or -ve value.
+
+  Update-timing [impl namespace metric tags value]
+  This is the function to report a [timing](https://github.com/statsd/statsd/blob/master/docs/metric_types.md#timing) to statsd.
+  Args:
+  - impl :  the class object that implements this protocol, i.e. an instance of the deftype for example
+  - namespace : the namespace of the metric e.g. `message-processing`
+  - metric : the metric for which the value is being generated e.g. `success`, the final metric is created concatenating the namespace and the metric `namespace.metric` - `message-processing.success`
+  - tags : these are the tags attached to each metric. They are passed in the form of a clojure map e.g. {:topic_entity \"stream\" :actor \"application\"} which can then be converted to statsd specific tags (see `ziggurat.clj-statsd-metrics-wrapper` namespace for example)
+  - value : the value which is to be reported for the timing.
+  "
   (initialize [impl statsd-config])
   (terminate  [impl])
   (update-counter [impl namespace metric tags signed-val])

--- a/src/ziggurat/server/routes.clj
+++ b/src/ziggurat/server/routes.clj
@@ -34,5 +34,4 @@
       (m/wrap-default-content-type-json)
       (wrap-newrelic-transaction)
       (m/wrap-errors)
-      (m/wrap-with-metrics)
       (wrap-with-logger)))

--- a/test/ziggurat/clj_statsd_metrics_wrapper_test.clj
+++ b/test/ziggurat/clj_statsd_metrics_wrapper_test.clj
@@ -53,7 +53,7 @@
           (update-counter namespace metric tags value)
           (is (true? @increment-called))))))
 
-  (deftest update-histogram-test
+  (deftest update-timing-test
     (testing "it calls statsd/timing with the correctly formatted arguments"
       (let [value 100
             timing-called (atom false)]
@@ -63,5 +63,5 @@
                                       (is (= clj-statsd-wrapper/rate rate))
                                       (is (= expected-tags tags))
                                       (reset! timing-called true))]
-          (update-histogram namespace metric tags value)
+          (update-timing namespace metric tags value)
           (is (true? @timing-called)))))))

--- a/test/ziggurat/fixtures.clj
+++ b/test/ziggurat/fixtures.clj
@@ -33,6 +33,11 @@
   (f)
   (mount/stop))
 
+(defn mount-metrics [f]
+  (mount/start (mount/only [#'ziggurat.metrics/statsd-reporter]))
+  (f)
+  (mount/stop #'ziggurat.metrics/statsd-reporter))
+
 (defn mount-tracer []
   (with-redefs [tracer/create-tracer (fn [] (MockTracer.))]
     (-> (mount/only [#'tracer/tracer])

--- a/test/ziggurat/messaging/consumer_test.clj
+++ b/test/ziggurat/messaging/consumer_test.clj
@@ -15,7 +15,8 @@
             [taoensso.nippy :as nippy]))
 
 (use-fixtures :once (join-fixtures [fix/init-rabbit-mq
-                                    fix/silence-logging]))
+                                    fix/silence-logging
+                                    fix/mount-metrics]))
 (defn- gen-message-payload [topic-entity]
   {:message {:gen-key (apply str (take 10 (repeatedly #(char (+ (rand 26) 65)))))}
    :topic-entity topic-entity})

--- a/test/ziggurat/messaging/dead_set_test.clj
+++ b/test/ziggurat/messaging/dead_set_test.clj
@@ -6,7 +6,8 @@
             [ziggurat.util.rabbitmq :as rmq]))
 
 (use-fixtures :once (join-fixtures [fix/init-rabbit-mq
-                                    fix/silence-logging]))
+                                    fix/silence-logging
+                                    fix/mount-metrics]))
 
 (def topic-entity :default)
 (def default-message-payload {:message {:foo "bar"} :topic-entity topic-entity :retry-count 0})

--- a/test/ziggurat/metrics_test.clj
+++ b/test/ziggurat/metrics_test.clj
@@ -18,7 +18,7 @@
                    :actor "application_name"})
 
 (deftest increment-count-test
-  (with-redefs [config (assoc-in config [:ziggurat :metrics :implementation] "ziggurat.util.mock-metrics-implementation/->MockImpl")]
+  (with-redefs [config (assoc-in config [:ziggurat :metrics :constructor] "ziggurat.util.mock-metrics-implementation/->MockImpl")]
     (mount/start (mount/only [#'metrics/statsd-reporter]))
     (let [passed-metric-name         "metric3"
           expected-topic-entity-name "expected-topic-entity-name"
@@ -117,7 +117,7 @@
     (mount/stop #'metrics/statsd-reporter)))
 
 (deftest decrement-count-test
-  (with-redefs [config (assoc-in config [:ziggurat :metrics :implementation] "ziggurat.util.mock-metrics-implementation/->MockImpl")]
+  (with-redefs [config (assoc-in config [:ziggurat :metrics :constructor] "ziggurat.util.mock-metrics-implementation/->MockImpl")]
     (mount/start (mount/only [#'metrics/statsd-reporter]))
     (let [expected-topic-name "expected-topic-name"
           passed-metric-name  "metric3"
@@ -198,7 +198,7 @@
     (mount/stop #'metrics/statsd-reporter)))
 
 (deftest report-histogram-test
-  (with-redefs [config (assoc-in config [:ziggurat :metrics :implementation] "ziggurat.util.mock-metrics-implementation/->MockImpl")]
+  (with-redefs [config (assoc-in config [:ziggurat :metrics :constructor] "ziggurat.util.mock-metrics-implementation/->MockImpl")]
     (mount/start (mount/only [#'metrics/statsd-reporter]))
     (let [topic-entity-name "expected-topic-entity-name"
           input-tags        {:topic_name topic-entity-name}
@@ -324,14 +324,14 @@
         (is (= expected-report-histogram-call-counts @report-histogram-call-counts))))))
 
 (deftest initialise-metrics-library-test
-  (testing "It sets the implementation object to default (dropwizard) when no value is passed in configuration"
-    (with-redefs [ziggurat-config (constantly {:metrics {:implementation nil}})]
+  (testing "It sets the constructor object to default (dropwizard) when no value is passed in configuration"
+    (with-redefs [ziggurat-config (constantly {:metrics {:constructor nil}})]
       (metrics/initialise-metrics-library)
       (is (instance? DropwizardMetrics (deref metrics/metric-impl)))))
-  (testing "It sets the implementation object to the configured constructor's return value"
-    (with-redefs [ziggurat-config (constantly {:metrics {:implementation "ziggurat.clj-statsd-metrics-wrapper/->CljStatsd"}})]
+  (testing "It sets the constructor object to the configured constructor's return value"
+    (with-redefs [ziggurat-config (constantly {:metrics {:constructor "ziggurat.clj-statsd-metrics-wrapper/->CljStatsd"}})]
       (metrics/initialise-metrics-library)
       (is (instance? CljStatsd (deref metrics/metric-impl)))))
   (testing "It raises an exception when incorrect constructor has been configured"
-    (with-redefs [ziggurat-config (constantly {:metrics {:implementation "incorrect-constructor"}})]
+    (with-redefs [ziggurat-config (constantly {:metrics {:constructor "incorrect-constructor"}})]
       (is (thrown? RuntimeException (metrics/initialise-metrics-library))))))

--- a/test/ziggurat/metrics_test.clj
+++ b/test/ziggurat/metrics_test.clj
@@ -202,14 +202,15 @@
     (mount/start (mount/only [#'metrics/statsd-reporter]))
     (let [topic-entity-name "expected-topic-entity-name"
           input-tags        {:topic_name topic-entity-name}
-          time-val          10]
+          time-val          10
+          expected-metric   "all"]
       (testing "calls update-histogram with the correct arguments - vector as an argument"
         (let [metric-namespaces         [topic-entity-name "message-received-delay-histogram"]
               expected-metric-namespace (str topic-entity-name ".message-received-delay-histogram")
               expected-tags             default-tags]
           (with-redefs [mock-metrics/update-timing (fn [namespace metric tags value]
                                                      (is (= namespace expected-metric-namespace))
-                                                     (is (nil? metric))
+                                                     (is (= metric expected-metric))
                                                      (is (= tags expected-tags))
                                                      (is (= value time-val)))]
             (metrics/report-histogram metric-namespaces time-val input-tags))))
@@ -221,7 +222,7 @@
           (with-redefs [mock-metrics/update-timing (fn [namespace metric tags value]
                                                      (cond (= namespace metric-namespace) (swap! metric-namespaces-called conj namespace)
                                                            (= namespace actor-prefixed-metric-ns) (swap! metric-namespaces-called conj namespace))
-                                                     (is (nil? metric))
+                                                     (is (= metric expected-metric))
                                                      (is (= tags expected-tags))
                                                      (is (= value time-val)))]
             (metrics/report-histogram metric-namespace time-val input-tags)
@@ -235,7 +236,7 @@
           (with-redefs [mock-metrics/update-timing (fn [namespace metric tags value]
                                                      (cond (= namespace metric-namespace) (swap! metric-namespaces-called conj namespace)
                                                            (= namespace actor-prefixed-metric-ns) (swap! metric-namespaces-called conj namespace))
-                                                     (is (nil? metric))
+                                                     (is (= metric expected-metric))
                                                      (is (= tags expected-tags))
                                                      (is (= value time-val)))]
             (metrics/report-histogram metric-namespace time-val)

--- a/test/ziggurat/metrics_test.clj
+++ b/test/ziggurat/metrics_test.clj
@@ -26,30 +26,30 @@
               expected-namespace (str expected-topic-entity-name ".metric-ns")
               expected-tags      default-tags]
           (with-redefs [mock-metrics/update-counter (fn [namespace metric tags value]
-                                                    (is (= namespace expected-namespace))
-                                                    (is (= metric passed-metric-name))
-                                                    (is (= tags expected-tags))
-                                                    (is (= value expected-n)))]
+                                                      (is (= namespace expected-namespace))
+                                                      (is (= metric passed-metric-name))
+                                                      (is (= tags expected-tags))
+                                                      (is (= value expected-n)))]
             (metrics/increment-count metric-namespaces passed-metric-name expected-n input-tags))))
       (testing "calls update-counter with correct args - 3rd argument is a number"
         (let [metric-namespaces  ["metric" "ns"]
               expected-namespace "metric.ns"
               expected-tags      default-tags]
           (with-redefs [mock-metrics/update-counter (fn [namespace metric tags value]
-                                                    (is (= namespace expected-namespace))
-                                                    (is (= metric passed-metric-name))
-                                                    (is (= tags expected-tags))
-                                                    (is (= value expected-n)))]
+                                                      (is (= namespace expected-namespace))
+                                                      (is (= metric passed-metric-name))
+                                                      (is (= tags expected-tags))
+                                                      (is (= value expected-n)))]
             (metrics/increment-count metric-namespaces passed-metric-name expected-n))))
       (testing "calls update-counter with correct args - 3rd argument is a map"
         (let [metric-namespaces  ["metric" "ns"]
               expected-namespace "metric.ns"
               expected-tags      default-tags]
           (with-redefs [mock-metrics/update-counter (fn [namespace metric tags value]
-                                                    (is (= namespace expected-namespace))
-                                                    (is (= metric passed-metric-name))
-                                                    (is (= tags expected-tags))
-                                                    (is (= value expected-n)))]
+                                                      (is (= namespace expected-namespace))
+                                                      (is (= metric passed-metric-name))
+                                                      (is (= tags expected-tags))
+                                                      (is (= value expected-n)))]
             (metrics/increment-count metric-namespaces passed-metric-name expected-tags))))
       (testing "calls update-counter with correct args - string as an argument"
         (let [metric-namespace         "metric-ns"
@@ -57,11 +57,11 @@
               passed-tags              (merge input-tags default-tags)
               metric-namespaces-called (atom [])]
           (with-redefs [mock-metrics/update-counter (fn [namespace metric tags value]
-                                                    (cond (= namespace metric-namespace) (swap! metric-namespaces-called conj namespace)
-                                                          (= namespace actor-prefixed-metric-ns) (swap! metric-namespaces-called conj namespace))
-                                                    (is (= tags passed-tags))
-                                                    (is (= metric passed-metric-name))
-                                                    (is (= value expected-n)))]
+                                                      (cond (= namespace metric-namespace) (swap! metric-namespaces-called conj namespace)
+                                                            (= namespace actor-prefixed-metric-ns) (swap! metric-namespaces-called conj namespace))
+                                                      (is (= tags passed-tags))
+                                                      (is (= metric passed-metric-name))
+                                                      (is (= value expected-n)))]
             (metrics/increment-count metric-namespace passed-metric-name 1 passed-tags)
             (is (some #{metric-namespace} @metric-namespaces-called))
             (is (some #{actor-prefixed-metric-ns} @metric-namespaces-called)))))
@@ -70,10 +70,10 @@
               expected-namespace (str expected-topic-entity-name ".metric-ns")
               expected-tags      default-tags]
           (with-redefs [mock-metrics/update-counter (fn [namespace metric tags value]
-                                                    (is (= namespace expected-namespace))
-                                                    (is (= metric passed-metric-name))
-                                                    (is (= tags expected-tags))
-                                                    (is (= value expected-n)))]
+                                                      (is (= namespace expected-namespace))
+                                                      (is (= metric passed-metric-name))
+                                                      (is (= tags expected-tags))
+                                                      (is (= value expected-n)))]
             (metrics/increment-count metric-namespaces passed-metric-name))))
       (testing "calls update-counter with correct args - additional-tags is nil"
         (let [metric-namespace         "metric-ns"
@@ -81,11 +81,11 @@
               metric-namespaces-called (atom [])
               expected-tags            default-tags]
           (with-redefs [mock-metrics/update-counter (fn [namespace metric tags value]
-                                                    (cond (= namespace metric-namespace) (swap! metric-namespaces-called conj namespace)
-                                                          (= namespace actor-prefixed-metric-ns) (swap! metric-namespaces-called conj namespace))
-                                                    (is (= tags expected-tags))
-                                                    (is (= metric passed-metric-name))
-                                                    (is (= value expected-n)))]
+                                                      (cond (= namespace metric-namespace) (swap! metric-namespaces-called conj namespace)
+                                                            (= namespace actor-prefixed-metric-ns) (swap! metric-namespaces-called conj namespace))
+                                                      (is (= tags expected-tags))
+                                                      (is (= metric passed-metric-name))
+                                                      (is (= value expected-n)))]
             (metrics/increment-count metric-namespace passed-metric-name 1 nil)
             (is (some #{metric-namespace} @metric-namespaces-called))
             (is (some #{actor-prefixed-metric-ns} @metric-namespaces-called)))))
@@ -204,21 +204,23 @@
         (let [metric-namespaces         [topic-entity-name "message-received-delay-histogram"]
               expected-metric-namespace (str topic-entity-name ".message-received-delay-histogram")
               expected-tags             default-tags]
-          (with-redefs [mock-metrics/update-timing (fn [namespace tags value]
-                                                        (is (= namespace expected-metric-namespace))
-                                                        (is (= tags expected-tags))
-                                                        (is (= value time-val)))]
+          (with-redefs [mock-metrics/update-timing (fn [namespace metric tags value]
+                                                     (is (= namespace expected-metric-namespace))
+                                                     (is (nil? metric))
+                                                     (is (= tags expected-tags))
+                                                     (is (= value time-val)))]
             (metrics/report-histogram metric-namespaces time-val input-tags))))
       (testing "calls update-histogram with the correct arguments - string as an argument"
         (let [metric-namespace         "message-received-delay-histogram"
               actor-prefixed-metric-ns (str (:app-name (ziggurat-config)) "." metric-namespace)
               expected-tags            (merge default-tags input-tags)
               metric-namespaces-called (atom [])]
-          (with-redefs [mock-metrics/update-timing (fn [namespace tags value]
-                                                        (cond (= namespace metric-namespace) (swap! metric-namespaces-called conj namespace)
-                                                              (= namespace actor-prefixed-metric-ns) (swap! metric-namespaces-called conj namespace))
-                                                        (is (= tags expected-tags))
-                                                        (is (= value time-val)))]
+          (with-redefs [mock-metrics/update-timing (fn [namespace metric tags value]
+                                                     (cond (= namespace metric-namespace) (swap! metric-namespaces-called conj namespace)
+                                                           (= namespace actor-prefixed-metric-ns) (swap! metric-namespaces-called conj namespace))
+                                                     (is (nil? metric))
+                                                     (is (= tags expected-tags))
+                                                     (is (= value time-val)))]
             (metrics/report-histogram metric-namespace time-val input-tags)
             (is (some #{metric-namespace} @metric-namespaces-called))
             (is (some #{actor-prefixed-metric-ns} @metric-namespaces-called)))))
@@ -227,11 +229,12 @@
               actor-prefixed-metric-ns (str (:app-name (ziggurat-config)) "." metric-namespace)
               expected-tags            default-tags
               metric-namespaces-called (atom [])]
-          (with-redefs [mock-metrics/update-timing (fn [namespace tags value]
-                                                        (cond (= namespace metric-namespace) (swap! metric-namespaces-called conj namespace)
-                                                              (= namespace actor-prefixed-metric-ns) (swap! metric-namespaces-called conj namespace))
-                                                        (is (= tags expected-tags))
-                                                        (is (= value time-val)))]
+          (with-redefs [mock-metrics/update-timing (fn [namespace metric tags value]
+                                                     (cond (= namespace metric-namespace) (swap! metric-namespaces-called conj namespace)
+                                                           (= namespace actor-prefixed-metric-ns) (swap! metric-namespaces-called conj namespace))
+                                                     (is (nil? metric))
+                                                     (is (= tags expected-tags))
+                                                     (is (= value time-val)))]
             (metrics/report-histogram metric-namespace time-val)
             (is (some #{metric-namespace} @metric-namespaces-called))
             (is (some #{actor-prefixed-metric-ns} @metric-namespaces-called)))))

--- a/test/ziggurat/metrics_test.clj
+++ b/test/ziggurat/metrics_test.clj
@@ -8,7 +8,8 @@
             [clojure.tools.logging :as log])
   (:import (io.dropwizard.metrics5 Meter Histogram UniformReservoir MetricRegistry)))
 
-(use-fixtures :once fix/mount-only-config)
+(use-fixtures :once (join-fixtures [fix/mount-only-config
+                                    fix/mount-metrics]))
 
 (def default-tags {:env   "dev"
                    :actor "application_name"})

--- a/test/ziggurat/metrics_test.clj
+++ b/test/ziggurat/metrics_test.clj
@@ -1,255 +1,264 @@
 (ns ziggurat.metrics-test
   (:require [clojure.test :refer :all]
             [clojure.walk :refer [stringify-keys]]
-            [ziggurat.config :refer [ziggurat-config]]
+            [ziggurat.config :refer [ziggurat-config config]]
             [ziggurat.fixtures :as fix]
             [ziggurat.metrics :as metrics]
-            [ziggurat.dropwizard-metrics-wrapper :as dw-metrics]
-            [clojure.tools.logging :as log])
+            [ziggurat.util.mock-metrics-implementation :as mock-metrics]
+            [clojure.tools.logging :as log]
+            [mount.core :as mount])
   (:import (io.dropwizard.metrics5 Meter Histogram UniformReservoir MetricRegistry)))
 
-(use-fixtures :once (join-fixtures [fix/mount-only-config
-                                    fix/mount-metrics]))
+(use-fixtures :once (join-fixtures [fix/mount-only-config]))
 
 (def default-tags {:env   "dev"
                    :actor "application_name"})
 
 (deftest increment-count-test
-  (let [passed-metric-name         "metric3"
-        expected-topic-entity-name "expected-topic-entity-name"
-        input-tags                 {:topic_name expected-topic-entity-name}
-        expected-n                 1]
-    (testing "calls update-counter with correct args - vector as an argument"
-      (let [metric-namespaces  [expected-topic-entity-name "metric-ns"]
-            expected-namespace (str expected-topic-entity-name ".metric-ns")
-            expected-tags      default-tags]
-        (with-redefs [dw-metrics/update-counter (fn [namespace metric tags value]
-                                                  (is (= namespace expected-namespace))
-                                                  (is (= metric passed-metric-name))
-                                                  (is (= tags expected-tags))
-                                                  (is (= value expected-n)))]
-          (metrics/increment-count metric-namespaces passed-metric-name expected-n input-tags))))
-    (testing "calls update-counter with correct args - 3rd argument is a number"
-      (let [metric-namespaces  ["metric" "ns"]
-            expected-namespace "metric.ns"
-            expected-tags      default-tags]
-        (with-redefs [dw-metrics/update-counter (fn [namespace metric tags value]
-                                                  (is (= namespace expected-namespace))
-                                                  (is (= metric passed-metric-name))
-                                                  (is (= tags expected-tags))
-                                                  (is (= value expected-n)))]
-          (metrics/increment-count metric-namespaces passed-metric-name expected-n))))
-    (testing "calls update-counter with correct args - 3rd argument is a map"
-      (let [metric-namespaces  ["metric" "ns"]
-            expected-namespace "metric.ns"
-            expected-tags      default-tags]
-        (with-redefs [dw-metrics/update-counter (fn [namespace metric tags value]
-                                                  (is (= namespace expected-namespace))
-                                                  (is (= metric passed-metric-name))
-                                                  (is (= tags expected-tags))
-                                                  (is (= value expected-n)))]
-          (metrics/increment-count metric-namespaces passed-metric-name expected-tags))))
-    (testing "calls update-counter with correct args - string as an argument"
-      (let [metric-namespace         "metric-ns"
-            actor-prefixed-metric-ns (str (:app-name (ziggurat-config)) "." metric-namespace)
-            passed-tags              (merge input-tags default-tags)
-            metric-namespaces-called (atom [])]
-        (with-redefs [dw-metrics/update-counter (fn [namespace metric tags value]
-                                                  (cond (= namespace metric-namespace) (swap! metric-namespaces-called conj namespace)
-                                                        (= namespace actor-prefixed-metric-ns) (swap! metric-namespaces-called conj namespace))
-                                                  (is (= tags passed-tags))
-                                                  (is (= metric passed-metric-name))
-                                                  (is (= value expected-n)))]
-          (metrics/increment-count metric-namespace passed-metric-name 1 passed-tags)
-          (is (some #{metric-namespace} @metric-namespaces-called))
-          (is (some #{actor-prefixed-metric-ns} @metric-namespaces-called)))))
-    (testing "calls update-counter with correct args - w/o additional-tags argument"
-      (let [metric-namespaces  [expected-topic-entity-name "metric-ns"]
-            expected-namespace (str expected-topic-entity-name ".metric-ns")
-            expected-tags      default-tags]
-        (with-redefs [dw-metrics/update-counter (fn [namespace metric tags value]
-                                                  (is (= namespace expected-namespace))
-                                                  (is (= metric passed-metric-name))
-                                                  (is (= tags expected-tags))
-                                                  (is (= value expected-n)))]
-          (metrics/increment-count metric-namespaces passed-metric-name))))
-    (testing "calls update-counter with correct args - additional-tags is nil"
-      (let [metric-namespace         "metric-ns"
-            actor-prefixed-metric-ns (str (:app-name (ziggurat-config)) "." metric-namespace)
-            metric-namespaces-called (atom [])
-            expected-tags            default-tags]
-        (with-redefs [dw-metrics/update-counter (fn [namespace metric tags value]
-                                                  (cond (= namespace metric-namespace) (swap! metric-namespaces-called conj namespace)
-                                                        (= namespace actor-prefixed-metric-ns) (swap! metric-namespaces-called conj namespace))
-                                                  (is (= tags expected-tags))
-                                                  (is (= metric passed-metric-name))
-                                                  (is (= value expected-n)))]
-          (metrics/increment-count metric-namespace passed-metric-name 1 nil)
-          (is (some #{metric-namespace} @metric-namespaces-called))
-          (is (some #{actor-prefixed-metric-ns} @metric-namespaces-called)))))
-    (testing "-incrementCount calls increment-count with the correct arguments"
-      (let [metric-namespace        "namespace"
-            increment-count-called? (atom false)]
-        (with-redefs [metrics/increment-count (fn [actual-metric-namespace actual-metric]
-                                                (if (and (= actual-metric-namespace metric-namespace)
-                                                         (= actual-metric passed-metric-name))
-                                                  (reset! increment-count-called? true)))]
-          (metrics/-incrementCount metric-namespace passed-metric-name)
-          (is (true? @increment-count-called?))))
-      (let [tags                    (doto (java.util.HashMap.)
-                                      (.put ":foo" "bar")
-                                      (.put ":bar" "foo"))
-            expected-tags           {:foo "bar" :bar "foo"}
-            increment-count-called? (atom false)
-            metric-namespace        "namespace"]
-        (with-redefs [metrics/increment-count (fn [actual-namespace actual-metric actual-additional-tags]
-                                                (if (and (= actual-namespace metric-namespace)
-                                                         (= actual-metric passed-metric-name)
-                                                         (= actual-additional-tags expected-tags))
-                                                  (reset! increment-count-called? true)))]
-          (metrics/-incrementCount metric-namespace passed-metric-name tags)
-          (is (true? @increment-count-called?)))))))
+  (with-redefs [config (assoc-in config [:ziggurat :metrics :implementation] "ziggurat.util.mock-metrics-implementation/->MockImpl")]
+    (mount/start (mount/only [#'metrics/statsd-reporter]))
+    (let [passed-metric-name         "metric3"
+          expected-topic-entity-name "expected-topic-entity-name"
+          input-tags                 {:topic_name expected-topic-entity-name}
+          expected-n                 1]
+      (testing "calls update-counter with correct args - vector as an argument"
+        (let [metric-namespaces  [expected-topic-entity-name "metric-ns"]
+              expected-namespace (str expected-topic-entity-name ".metric-ns")
+              expected-tags      default-tags]
+          (with-redefs [mock-metrics/update-counter (fn [namespace metric tags value]
+                                                    (is (= namespace expected-namespace))
+                                                    (is (= metric passed-metric-name))
+                                                    (is (= tags expected-tags))
+                                                    (is (= value expected-n)))]
+            (metrics/increment-count metric-namespaces passed-metric-name expected-n input-tags))))
+      (testing "calls update-counter with correct args - 3rd argument is a number"
+        (let [metric-namespaces  ["metric" "ns"]
+              expected-namespace "metric.ns"
+              expected-tags      default-tags]
+          (with-redefs [mock-metrics/update-counter (fn [namespace metric tags value]
+                                                    (is (= namespace expected-namespace))
+                                                    (is (= metric passed-metric-name))
+                                                    (is (= tags expected-tags))
+                                                    (is (= value expected-n)))]
+            (metrics/increment-count metric-namespaces passed-metric-name expected-n))))
+      (testing "calls update-counter with correct args - 3rd argument is a map"
+        (let [metric-namespaces  ["metric" "ns"]
+              expected-namespace "metric.ns"
+              expected-tags      default-tags]
+          (with-redefs [mock-metrics/update-counter (fn [namespace metric tags value]
+                                                    (is (= namespace expected-namespace))
+                                                    (is (= metric passed-metric-name))
+                                                    (is (= tags expected-tags))
+                                                    (is (= value expected-n)))]
+            (metrics/increment-count metric-namespaces passed-metric-name expected-tags))))
+      (testing "calls update-counter with correct args - string as an argument"
+        (let [metric-namespace         "metric-ns"
+              actor-prefixed-metric-ns (str (:app-name (ziggurat-config)) "." metric-namespace)
+              passed-tags              (merge input-tags default-tags)
+              metric-namespaces-called (atom [])]
+          (with-redefs [mock-metrics/update-counter (fn [namespace metric tags value]
+                                                    (cond (= namespace metric-namespace) (swap! metric-namespaces-called conj namespace)
+                                                          (= namespace actor-prefixed-metric-ns) (swap! metric-namespaces-called conj namespace))
+                                                    (is (= tags passed-tags))
+                                                    (is (= metric passed-metric-name))
+                                                    (is (= value expected-n)))]
+            (metrics/increment-count metric-namespace passed-metric-name 1 passed-tags)
+            (is (some #{metric-namespace} @metric-namespaces-called))
+            (is (some #{actor-prefixed-metric-ns} @metric-namespaces-called)))))
+      (testing "calls update-counter with correct args - w/o additional-tags argument"
+        (let [metric-namespaces  [expected-topic-entity-name "metric-ns"]
+              expected-namespace (str expected-topic-entity-name ".metric-ns")
+              expected-tags      default-tags]
+          (with-redefs [mock-metrics/update-counter (fn [namespace metric tags value]
+                                                    (is (= namespace expected-namespace))
+                                                    (is (= metric passed-metric-name))
+                                                    (is (= tags expected-tags))
+                                                    (is (= value expected-n)))]
+            (metrics/increment-count metric-namespaces passed-metric-name))))
+      (testing "calls update-counter with correct args - additional-tags is nil"
+        (let [metric-namespace         "metric-ns"
+              actor-prefixed-metric-ns (str (:app-name (ziggurat-config)) "." metric-namespace)
+              metric-namespaces-called (atom [])
+              expected-tags            default-tags]
+          (with-redefs [mock-metrics/update-counter (fn [namespace metric tags value]
+                                                    (cond (= namespace metric-namespace) (swap! metric-namespaces-called conj namespace)
+                                                          (= namespace actor-prefixed-metric-ns) (swap! metric-namespaces-called conj namespace))
+                                                    (is (= tags expected-tags))
+                                                    (is (= metric passed-metric-name))
+                                                    (is (= value expected-n)))]
+            (metrics/increment-count metric-namespace passed-metric-name 1 nil)
+            (is (some #{metric-namespace} @metric-namespaces-called))
+            (is (some #{actor-prefixed-metric-ns} @metric-namespaces-called)))))
+      (testing "-incrementCount calls increment-count with the correct arguments"
+        (let [metric-namespace        "namespace"
+              increment-count-called? (atom false)]
+          (with-redefs [metrics/increment-count (fn [actual-metric-namespace actual-metric]
+                                                  (if (and (= actual-metric-namespace metric-namespace)
+                                                           (= actual-metric passed-metric-name))
+                                                    (reset! increment-count-called? true)))]
+            (metrics/-incrementCount metric-namespace passed-metric-name)
+            (is (true? @increment-count-called?))))
+        (let [tags                    (doto (java.util.HashMap.)
+                                        (.put ":foo" "bar")
+                                        (.put ":bar" "foo"))
+              expected-tags           {:foo "bar" :bar "foo"}
+              increment-count-called? (atom false)
+              metric-namespace        "namespace"]
+          (with-redefs [metrics/increment-count (fn [actual-namespace actual-metric actual-additional-tags]
+                                                  (if (and (= actual-namespace metric-namespace)
+                                                           (= actual-metric passed-metric-name)
+                                                           (= actual-additional-tags expected-tags))
+                                                    (reset! increment-count-called? true)))]
+            (metrics/-incrementCount metric-namespace passed-metric-name tags)
+            (is (true? @increment-count-called?))))))
+    (mount/stop #'metrics/statsd-reporter)))
 
 (deftest decrement-count-test
-  (let [expected-topic-name "expected-topic-name"
-        passed-metric-name  "metric3"
-        input-tags          {:topic_name expected-topic-name}
-        expected-n          -1
-        n                   1]
-    (testing "calls metrics library update-counter with the correct args - vector as an argument"
-      (let [expected-tags              default-tags
-            expected-metric-namespaces [expected-topic-name "metric-ns"]
-            expected-namespace         (str expected-topic-name ".metric-ns")]
-        (with-redefs [dw-metrics/update-counter (fn [namespace metric tags value]
-                                                  (is (= namespace expected-namespace))
-                                                  (is (= metric passed-metric-name))
-                                                  (is (= tags expected-tags))
-                                                  (is (= value expected-n)))]
-          (metrics/decrement-count expected-metric-namespaces passed-metric-name n input-tags))))
-    (testing "calls metrics library update-counter with the correct args - string as an argument"
-      (let [expected-tags            (merge default-tags input-tags)
-            metric-namespace         "metric-ns"
-            actor-prefixed-metric-ns (str (:app-name (ziggurat-config)) "." metric-namespace)
-            metric-namespaces-called (atom [])]
-        (with-redefs [dw-metrics/update-counter (fn [namespace metric tags value]
-                                                  (cond (= namespace metric-namespace) (swap! metric-namespaces-called conj namespace)
-                                                        (= namespace actor-prefixed-metric-ns) (swap! metric-namespaces-called conj namespace))
-                                                  (is (= tags expected-tags))
-                                                  (is (= metric passed-metric-name))
-                                                  (is (= value expected-n)))]
-          (metrics/decrement-count metric-namespace passed-metric-name n input-tags)
-          (is (some #{metric-namespace} @metric-namespaces-called))
-          (is (some #{actor-prefixed-metric-ns} @metric-namespaces-called)))))
-    (testing "calls metrics library update-counter with the correct args - without topic name on the namespace"
-      (let [expected-additional-tags (merge default-tags input-tags)
-            metric-namespaces        ["metric" "ns"]
-            expected-namespace       "metric.ns"
-            expected-tags            (merge default-tags input-tags)]
-        (with-redefs [dw-metrics/update-counter (fn [namespace metric tags value]
-                                                  (is (= namespace expected-namespace))
-                                                  (is (= metric passed-metric-name))
-                                                  (is (= tags expected-tags))
-                                                  (is (= value expected-n)))]
-          (metrics/decrement-count metric-namespaces passed-metric-name n input-tags))))
-    (testing "calls metrics library update-counter with the correct args - additional-tags is nil"
-      (let [expected-tags            default-tags
-            metric-namespace         "metric-ns"
-            actor-prefixed-metric-ns (str (:app-name (ziggurat-config)) "." metric-namespace)
-            metric-namespaces-called (atom [])]
-        (with-redefs [dw-metrics/update-counter (fn [namespace metric tags value]
-                                                  (cond (= namespace metric-namespace) (swap! metric-namespaces-called conj namespace)
-                                                        (= namespace actor-prefixed-metric-ns) (swap! metric-namespaces-called conj namespace))
-                                                  (is (= tags expected-tags))
-                                                  (is (= metric passed-metric-name))
-                                                  (is (= value expected-n)))]
-          (metrics/decrement-count metric-namespace passed-metric-name n nil)
-          (is (some #{metric-namespace} @metric-namespaces-called))
-          (is (some #{actor-prefixed-metric-ns} @metric-namespaces-called)))))
-    (testing "-decrementCount passes the correct arguments to decrement-count"
-      (let [metric-namespace        "namespace"
-            decrement-count-called? (atom false)]
-        (with-redefs [metrics/decrement-count (fn [actual-metric-namespace actual-metric]
-                                                (if (and (= actual-metric-namespace metric-namespace)
-                                                         (= actual-metric passed-metric-name))
-                                                  (reset! decrement-count-called? true)))]
-          (metrics/-decrementCount metric-namespace passed-metric-name)
-          (is (true? @decrement-count-called?))))
-      (let [tags                    (doto (java.util.HashMap.)
-                                      (.put ":foo" "bar")
-                                      (.put ":bar" "foo"))
-            expected-tags           {:foo "bar" :bar "foo"}
-            decrement-count-called? (atom false)
-            metric-namespace        "namespace"]
-        (with-redefs [metrics/decrement-count (fn [actual-namespace actual-metric actual-additional-tags]
-                                                (if (and (= actual-namespace metric-namespace)
-                                                         (= actual-metric passed-metric-name)
-                                                         (= actual-additional-tags expected-tags))
-                                                  (reset! decrement-count-called? true)))]
-          (metrics/-decrementCount metric-namespace passed-metric-name tags)
-          (is (true? @decrement-count-called?)))))))
+  (with-redefs [config (assoc-in config [:ziggurat :metrics :implementation] "ziggurat.util.mock-metrics-implementation/->MockImpl")]
+    (mount/start (mount/only [#'metrics/statsd-reporter]))
+    (let [expected-topic-name "expected-topic-name"
+          passed-metric-name  "metric3"
+          input-tags          {:topic_name expected-topic-name}
+          expected-n          -1
+          n                   1]
+      (testing "calls metrics library update-counter with the correct args - vector as an argument"
+        (let [expected-tags              default-tags
+              expected-metric-namespaces [expected-topic-name "metric-ns"]
+              expected-namespace         (str expected-topic-name ".metric-ns")]
+          (with-redefs [mock-metrics/update-counter (fn [namespace metric tags value]
+                                                      (is (= namespace expected-namespace))
+                                                      (is (= metric passed-metric-name))
+                                                      (is (= tags expected-tags))
+                                                      (is (= value expected-n)))]
+            (metrics/decrement-count expected-metric-namespaces passed-metric-name n input-tags))))
+      (testing "calls metrics library update-counter with the correct args - string as an argument"
+        (let [expected-tags            (merge default-tags input-tags)
+              metric-namespace         "metric-ns"
+              actor-prefixed-metric-ns (str (:app-name (ziggurat-config)) "." metric-namespace)
+              metric-namespaces-called (atom [])]
+          (with-redefs [mock-metrics/update-counter (fn [namespace metric tags value]
+                                                      (cond (= namespace metric-namespace) (swap! metric-namespaces-called conj namespace)
+                                                            (= namespace actor-prefixed-metric-ns) (swap! metric-namespaces-called conj namespace))
+                                                      (is (= tags expected-tags))
+                                                      (is (= metric passed-metric-name))
+                                                      (is (= value expected-n)))]
+            (metrics/decrement-count metric-namespace passed-metric-name n input-tags)
+            (is (some #{metric-namespace} @metric-namespaces-called))
+            (is (some #{actor-prefixed-metric-ns} @metric-namespaces-called)))))
+      (testing "calls metrics library update-counter with the correct args - without topic name on the namespace"
+        (let [expected-additional-tags (merge default-tags input-tags)
+              metric-namespaces        ["metric" "ns"]
+              expected-namespace       "metric.ns"
+              expected-tags            (merge default-tags input-tags)]
+          (with-redefs [mock-metrics/update-counter (fn [namespace metric tags value]
+                                                      (is (= namespace expected-namespace))
+                                                      (is (= metric passed-metric-name))
+                                                      (is (= tags expected-tags))
+                                                      (is (= value expected-n)))]
+            (metrics/decrement-count metric-namespaces passed-metric-name n input-tags))))
+      (testing "calls metrics library update-counter with the correct args - additional-tags is nil"
+        (let [expected-tags            default-tags
+              metric-namespace         "metric-ns"
+              actor-prefixed-metric-ns (str (:app-name (ziggurat-config)) "." metric-namespace)
+              metric-namespaces-called (atom [])]
+          (with-redefs [mock-metrics/update-counter (fn [namespace metric tags value]
+                                                      (cond (= namespace metric-namespace) (swap! metric-namespaces-called conj namespace)
+                                                            (= namespace actor-prefixed-metric-ns) (swap! metric-namespaces-called conj namespace))
+                                                      (is (= tags expected-tags))
+                                                      (is (= metric passed-metric-name))
+                                                      (is (= value expected-n)))]
+            (metrics/decrement-count metric-namespace passed-metric-name n nil)
+            (is (some #{metric-namespace} @metric-namespaces-called))
+            (is (some #{actor-prefixed-metric-ns} @metric-namespaces-called)))))
+      (testing "-decrementCount passes the correct arguments to decrement-count"
+        (let [metric-namespace        "namespace"
+              decrement-count-called? (atom false)]
+          (with-redefs [metrics/decrement-count (fn [actual-metric-namespace actual-metric]
+                                                  (if (and (= actual-metric-namespace metric-namespace)
+                                                           (= actual-metric passed-metric-name))
+                                                    (reset! decrement-count-called? true)))]
+            (metrics/-decrementCount metric-namespace passed-metric-name)
+            (is (true? @decrement-count-called?))))
+        (let [tags                    (doto (java.util.HashMap.)
+                                        (.put ":foo" "bar")
+                                        (.put ":bar" "foo"))
+              expected-tags           {:foo "bar" :bar "foo"}
+              decrement-count-called? (atom false)
+              metric-namespace        "namespace"]
+          (with-redefs [metrics/decrement-count (fn [actual-namespace actual-metric actual-additional-tags]
+                                                  (if (and (= actual-namespace metric-namespace)
+                                                           (= actual-metric passed-metric-name)
+                                                           (= actual-additional-tags expected-tags))
+                                                    (reset! decrement-count-called? true)))]
+            (metrics/-decrementCount metric-namespace passed-metric-name tags)
+            (is (true? @decrement-count-called?))))))
+    (mount/stop #'metrics/statsd-reporter)))
 
 (deftest report-histogram-test
-  (let [topic-entity-name "expected-topic-entity-name"
-        input-tags        {:topic_name topic-entity-name}
-        time-val          10]
-    (testing "calls update-histogram with the correct arguments - vector as an argument"
-      (let [metric-namespaces         [topic-entity-name "message-received-delay-histogram"]
-            expected-metric-namespace (str topic-entity-name ".message-received-delay-histogram")
-            expected-tags             default-tags]
-        (with-redefs [dw-metrics/update-histogram (fn [namespace tags value]
-                                                    (is (= namespace expected-metric-namespace))
-                                                    (is (= tags expected-tags))
-                                                    (is (= value time-val)))]
-          (metrics/report-histogram metric-namespaces time-val input-tags))))
-    (testing "calls update-histogram with the correct arguments - string as an argument"
-      (let [metric-namespace         "message-received-delay-histogram"
-            actor-prefixed-metric-ns (str (:app-name (ziggurat-config)) "." metric-namespace)
-            expected-tags            (merge default-tags input-tags)
-            metric-namespaces-called (atom [])]
-        (with-redefs [dw-metrics/update-histogram (fn [namespace tags value]
-                                                    (cond (= namespace metric-namespace) (swap! metric-namespaces-called conj namespace)
-                                                          (= namespace actor-prefixed-metric-ns) (swap! metric-namespaces-called conj namespace))
-                                                    (is (= tags expected-tags))
-                                                    (is (= value time-val)))]
-          (metrics/report-histogram metric-namespace time-val input-tags)
-          (is (some #{metric-namespace} @metric-namespaces-called))
-          (is (some #{actor-prefixed-metric-ns} @metric-namespaces-called)))))
-    (testing "calls update-histogram with the correct arguments - w/o additional-tags argument"
-      (let [metric-namespace         "message-received-delay-histogram"
-            actor-prefixed-metric-ns (str (:app-name (ziggurat-config)) "." metric-namespace)
-            expected-tags            default-tags
-            metric-namespaces-called (atom [])]
-        (with-redefs [dw-metrics/update-histogram (fn [namespace tags value]
-                                                    (cond (= namespace metric-namespace) (swap! metric-namespaces-called conj namespace)
-                                                          (= namespace actor-prefixed-metric-ns) (swap! metric-namespaces-called conj namespace))
-                                                    (is (= tags expected-tags))
-                                                    (is (= value time-val)))]
-          (metrics/report-histogram metric-namespace time-val)
-          (is (some #{metric-namespace} @metric-namespaces-called))
-          (is (some #{actor-prefixed-metric-ns} @metric-namespaces-called)))))
-    (testing "report time java function passes the correct parameters to report time"
-      (let [metric-namespace         "namespace"
-            report-histogram-called? (atom false)]
-        (with-redefs [metrics/report-histogram (fn [actual-metric-namespace actual-time-val]
-                                                 (if (and (= actual-metric-namespace metric-namespace)
-                                                          (= actual-time-val time-val))
-                                                   (reset! report-histogram-called? true)))]
-          (metrics/-reportTime metric-namespace time-val)
-          (is (true? @report-histogram-called?))))
-      (let [metric-namespace         "namespace"
-            tags                     (doto (java.util.HashMap.)
-                                       (.put ":foo" "bar")
-                                       (.put ":bar" "foo"))
-            expected-tags            {:foo "bar" :bar "foo"}
-            report-histogram-called? (atom false)]
-        (with-redefs [metrics/report-histogram (fn [actual-metric-namespace actual-time-val actual-additional-tags]
-                                                 (is (= actual-additional-tags expected-tags))
-                                                 (if (and (= actual-metric-namespace metric-namespace)
-                                                          (= actual-time-val time-val)
-                                                          (= actual-additional-tags expected-tags))
-                                                   (reset! report-histogram-called? true)))]
-          (metrics/-reportTime metric-namespace time-val tags)
-          (is (true? @report-histogram-called?)))))))
+  (with-redefs [config (assoc-in config [:ziggurat :metrics :implementation] "ziggurat.util.mock-metrics-implementation/->MockImpl")]
+    (mount/start (mount/only [#'metrics/statsd-reporter]))
+    (let [topic-entity-name "expected-topic-entity-name"
+          input-tags        {:topic_name topic-entity-name}
+          time-val          10]
+      (testing "calls update-histogram with the correct arguments - vector as an argument"
+        (let [metric-namespaces         [topic-entity-name "message-received-delay-histogram"]
+              expected-metric-namespace (str topic-entity-name ".message-received-delay-histogram")
+              expected-tags             default-tags]
+          (with-redefs [mock-metrics/update-timing (fn [namespace tags value]
+                                                        (is (= namespace expected-metric-namespace))
+                                                        (is (= tags expected-tags))
+                                                        (is (= value time-val)))]
+            (metrics/report-histogram metric-namespaces time-val input-tags))))
+      (testing "calls update-histogram with the correct arguments - string as an argument"
+        (let [metric-namespace         "message-received-delay-histogram"
+              actor-prefixed-metric-ns (str (:app-name (ziggurat-config)) "." metric-namespace)
+              expected-tags            (merge default-tags input-tags)
+              metric-namespaces-called (atom [])]
+          (with-redefs [mock-metrics/update-timing (fn [namespace tags value]
+                                                        (cond (= namespace metric-namespace) (swap! metric-namespaces-called conj namespace)
+                                                              (= namespace actor-prefixed-metric-ns) (swap! metric-namespaces-called conj namespace))
+                                                        (is (= tags expected-tags))
+                                                        (is (= value time-val)))]
+            (metrics/report-histogram metric-namespace time-val input-tags)
+            (is (some #{metric-namespace} @metric-namespaces-called))
+            (is (some #{actor-prefixed-metric-ns} @metric-namespaces-called)))))
+      (testing "calls update-histogram with the correct arguments - w/o additional-tags argument"
+        (let [metric-namespace         "message-received-delay-histogram"
+              actor-prefixed-metric-ns (str (:app-name (ziggurat-config)) "." metric-namespace)
+              expected-tags            default-tags
+              metric-namespaces-called (atom [])]
+          (with-redefs [mock-metrics/update-timing (fn [namespace tags value]
+                                                        (cond (= namespace metric-namespace) (swap! metric-namespaces-called conj namespace)
+                                                              (= namespace actor-prefixed-metric-ns) (swap! metric-namespaces-called conj namespace))
+                                                        (is (= tags expected-tags))
+                                                        (is (= value time-val)))]
+            (metrics/report-histogram metric-namespace time-val)
+            (is (some #{metric-namespace} @metric-namespaces-called))
+            (is (some #{actor-prefixed-metric-ns} @metric-namespaces-called)))))
+      (testing "report time java function passes the correct parameters to report time"
+        (let [metric-namespace         "namespace"
+              report-histogram-called? (atom false)]
+          (with-redefs [metrics/report-histogram (fn [actual-metric-namespace actual-time-val]
+                                                   (if (and (= actual-metric-namespace metric-namespace)
+                                                            (= actual-time-val time-val))
+                                                     (reset! report-histogram-called? true)))]
+            (metrics/-reportTime metric-namespace time-val)
+            (is (true? @report-histogram-called?))))
+        (let [metric-namespace         "namespace"
+              tags                     (doto (java.util.HashMap.)
+                                         (.put ":foo" "bar")
+                                         (.put ":bar" "foo"))
+              expected-tags            {:foo "bar" :bar "foo"}
+              report-histogram-called? (atom false)]
+          (with-redefs [metrics/report-histogram (fn [actual-metric-namespace actual-time-val actual-additional-tags]
+                                                   (is (= actual-additional-tags expected-tags))
+                                                   (if (and (= actual-metric-namespace metric-namespace)
+                                                            (= actual-time-val time-val)
+                                                            (= actual-additional-tags expected-tags))
+                                                     (reset! report-histogram-called? true)))]
+            (metrics/-reportTime metric-namespace time-val tags)
+            (is (true? @report-histogram-called?))))))
+    (mount/stop #'metrics/statsd-reporter)))
 
 (deftest report-time-test
   (let [metric-namespace "metric-namespace"

--- a/test/ziggurat/streams_test.clj
+++ b/test/ziggurat/streams_test.clj
@@ -17,7 +17,8 @@
            [io.opentracing.tag Tags]))
 
 (use-fixtures :once (join-fixtures [fix/mount-config-with-tracer
-                                    fix/silence-logging]))
+                                    fix/silence-logging
+                                    fix/mount-metrics]))
 
 (defn- props []
   (doto (Properties.)

--- a/test/ziggurat/util/mock_metrics_implementation.clj
+++ b/test/ziggurat/util/mock_metrics_implementation.clj
@@ -8,7 +8,7 @@
 (defn update-counter [namespace metric tags signed-val]
   nil)
 
-(defn update-timing  [namespace metric tags signed-val]
+(defn update-timing  [namespace metric tags val]
   nil)
 
 (defn terminate []
@@ -19,4 +19,4 @@
   (initialize [this statsd-config] (initialize statsd-config))
   (terminate [this] (terminate))
   (update-counter [this namespace metric tags signed-val] (update-counter namespace metric tags signed-val))
-  (update-histogram [this namespace metric tags signed-val] (update-timing namespace metric tags signed-val)))
+  (update-timing [this namespace metric tags val] (update-timing namespace metric tags val)))

--- a/test/ziggurat/util/mock_metrics_implementation.clj
+++ b/test/ziggurat/util/mock_metrics_implementation.clj
@@ -1,6 +1,6 @@
 (ns ziggurat.util.mock-metrics-implementation
   (:require [clojure.test :refer :all])
-  (:import (ziggurat.metrics_interface MetricsLib)))
+  (:import (ziggurat.metrics_interface MetricsProtocol)))
 
 (defn initialize [statsd-config]
   nil)
@@ -15,7 +15,7 @@
   nil)
 
 (deftype MockImpl []
-  MetricsLib
+  MetricsProtocol
   (initialize [this statsd-config] (initialize statsd-config))
   (terminate [this] (terminate))
   (update-counter [this namespace metric tags signed-val] (update-counter namespace metric tags signed-val))

--- a/test/ziggurat/util/mock_metrics_implementation.clj
+++ b/test/ziggurat/util/mock_metrics_implementation.clj
@@ -1,0 +1,22 @@
+(ns ziggurat.util.mock-metrics-implementation
+  (:require [clojure.test :refer :all])
+  (:import (ziggurat.metrics_interface MetricsLib)))
+
+(defn initialize [statsd-config]
+  nil)
+
+(defn update-counter [namespace metric tags signed-val]
+  nil)
+
+(defn update-timing  [namespace metric tags signed-val]
+  nil)
+
+(defn terminate []
+  nil)
+
+(deftype MockImpl []
+  MetricsLib
+  (initialize [this statsd-config] (initialize statsd-config))
+  (terminate [this] (terminate))
+  (update-counter [this namespace metric tags signed-val] (update-counter namespace metric tags signed-val))
+  (update-histogram [this namespace metric tags signed-val] (update-timing namespace metric tags signed-val)))


### PR DESCRIPTION
Introduces a {:ziggurat {:metrics {:constructor}}} configuration key that accepts a constructor (of a class that implements MetricsLib interface).

Renames interface fn `update-histogram` to `update-timing` as timing is the statsd metric_type.