### PR TITLE
Added functions to be accessible via REPL

### DIFF
--- a/resources/config.test.ci.edn
+++ b/resources/config.test.ci.edn
@@ -38,6 +38,7 @@
                                                         :stream-threads-count [1 :int]
                                                         :origin-topic         "topic"
                                                         :upgrade-from         "1.1"
+                                                        :changelog-topic-replication-factor [1 :int]
                                                         :channels             {:channel-1 {:worker-count [10 :int]
                                                                                            :retry        {:type    [:linear :keyword]
                                                                                                           :count   [5 :int]

--- a/resources/config.test.edn
+++ b/resources/config.test.edn
@@ -42,6 +42,7 @@
                                                         :origin-topic         "topic"
                                                         :upgrade-from         "1.1"
                                                         :consumer-type        :default
+                                                        :changelog-topic-replication-factor [1 :int]
                                                         :channels             {:channel-1 {:worker-count [10 :int]
                                                                                            :retry        {:type    [:linear :keyword]
                                                                                                           :count   [5 :int]

--- a/src/ziggurat/server/routes.clj
+++ b/src/ziggurat/server/routes.clj
@@ -6,7 +6,6 @@
             [ring.middleware.multipart-params :refer [wrap-multipart-params]]
             [ring.logger :refer [wrap-with-logger]]
             [ziggurat.resource.dead-set :as ds]
-            [ziggurat.streams :as streams]
             [ziggurat.server.middleware :as m]))
 
 (defn ping [_request]
@@ -21,8 +20,6 @@
    ["v1/dead_set" {:delete (ds/delete-messages)}]
    ["v1/dead_set/replay" {:post (ds/get-replay)}]
    ["v1/dead_set" {:get (ds/get-view)}]
-   ["v1/stream/stop" {:post (streams/stop-stream)}]
-   ["v1/stream/start" {:post (streams/start-stream)}]
    [true (fn [_req] (ring.util.response/not-found ""))]])
 
 (defn handler [actor-routes]

--- a/src/ziggurat/server/routes.clj
+++ b/src/ziggurat/server/routes.clj
@@ -6,6 +6,7 @@
             [ring.middleware.multipart-params :refer [wrap-multipart-params]]
             [ring.logger :refer [wrap-with-logger]]
             [ziggurat.resource.dead-set :as ds]
+            [ziggurat.streams :as streams]
             [ziggurat.server.middleware :as m]))
 
 (defn ping [_request]
@@ -20,6 +21,8 @@
    ["v1/dead_set" {:delete (ds/delete-messages)}]
    ["v1/dead_set/replay" {:post (ds/get-replay)}]
    ["v1/dead_set" {:get (ds/get-view)}]
+   ["v1/stream/stop" {:post (streams/stop-stream)}]
+   ["v1/stream/start" {:post (streams/start-stream)}]
    [true (fn [_req] (ring.util.response/not-found ""))]])
 
 (defn handler [actor-routes]

--- a/src/ziggurat/streams.clj
+++ b/src/ziggurat/streams.clj
@@ -162,13 +162,13 @@
   (let [stream-state (.state stream)]
     (if (= stream-state KafkaStreams$State/NOT_RUNNING)
       (log/error
-        (str
-          "Kafka stream cannot be stopped at the moment, current state is "
-          stream-state))
+       (str
+        "Kafka stream cannot be stopped at the moment, current state is "
+        stream-state))
       (do
         (.close stream)
         (log/info
-          (str "Stopping Kafka stream with topic-entity " topic-entity))))))
+         (str "Stopping Kafka stream with topic-entity " topic-entity))))))
 
 (defn stop-stream [topic-entity]
   (let [stream (get stream topic-entity)]
@@ -303,9 +303,9 @@
     (if (and (= (.state stream) KafkaStreams$State/NOT_RUNNING)
              (= stream-topic-entity topic-entity))
       (let [new-stream-object-map (start-streams
-                                    (hash-map stream-topic-entity
-                                              (get (:stream-routes (mount/args))
-                                                   stream-topic-entity)))]
+                                   (hash-map stream-topic-entity
+                                             (get (:stream-routes (mount/args))
+                                                  stream-topic-entity)))]
         (assoc new-stream-map
                stream-topic-entity
                (get new-stream-object-map stream-topic-entity)))

--- a/src/ziggurat/streams.clj
+++ b/src/ziggurat/streams.clj
@@ -159,10 +159,15 @@
 
 (defn close-stream
   [topic-entity stream]
-  (if (not (= (.state stream) KafkaStreams$State/NOT_RUNNING))
-    (do (.close stream)
-        (log/info (str "Stopping Kafka stream with topic-entity " topic-entity)))
-    (log/error (str "Kafka stream cannot be stopped at the moment, current state is " (.state stream)))))
+  (if-not (= (.state stream) KafkaStreams$State/NOT_RUNNING)
+    (do
+      (.close stream)
+      (log/info
+       (str "Stopping Kafka stream with topic-entity " topic-entity)))
+    (log/error
+     (str
+      "Kafka stream cannot be stopped at the moment, current state is "
+      (.state stream)))))
 
 (defn stop-stream [topic-entity]
   (let [stream (get stream topic-entity)]

--- a/src/ziggurat/streams.clj
+++ b/src/ziggurat/streams.clj
@@ -297,7 +297,7 @@
 
 (defn start-stream
   [topic-entity]
-  (if (get (:stream-routes (mount/args)) topic-entity)
+  (if (seq (select-keys ziggurat.streams/stream [topic-entity]))
     (mount/start-with-states {#'ziggurat.streams/stream
                               {:start (fn []
                                         (reduce (fn [new-stream-map stream-object]

--- a/src/ziggurat/streams.clj
+++ b/src/ziggurat/streams.clj
@@ -160,14 +160,21 @@
 (defn stop-stream [topic-entity]
   (if (get stream topic-entity)
     (do (.close (get stream topic-entity))
-        (log/info (str "Stopping Kafka stream with topic-entity" topic-entity)))
+        (log/info (str "Stopping Kafka stream with topic-entity " topic-entity)))
     (log/error "No Kafka stream with provided topic-entity exists")))
 
 (defn start-stream [topic-entity]
-  (if (get stream topic-entity)
-    (do (.start (get stream topic-entity))
-        (log/info "Kafka stream successfully started"))
-    (log/error "No Kafka stream with provided topic-entity exists")))
+  (log/info KafkaStreams)
+  (let [stream (get stream topic-entity)]
+    (if stream
+      (let [state (.state stream)]
+        (log/info "--------------------------------------------------------------------")
+        (log/info org.apache.kafka.streams.KafkaStreams/values)
+        (if (= state org.apache.kafka.streams.KafkaStreams$State/NOT_RUNNING)
+          (do (.start stream)
+              (log/info (str "Kafka stream with entity " topic-entity " successfully started")))
+          (log/error "Kafka stream already up and running")))
+      (log/error "No Kafka stream with provided topic-entity exists"))))
 
 (defn stop-streams [streams]
   (log/debug "Stopping Kafka streams")

--- a/src/ziggurat/streams.clj
+++ b/src/ziggurat/streams.clj
@@ -154,6 +154,25 @@
   (.transformValues stream-builder (header-transformer-supplier) (into-array [(.name (store-supplier-builder))])))
 
 (declare stream)
+(def stream-map {})
+
+(defn stop-stream [topic-entity]
+  (log/debug (str "Stopping Kafka stream with topic-entity" topic-entity))
+  (if (get stream-map topic-entity)
+    (do (.close (get stream-map topic-entity))
+        {:status 200
+         :body   {:message "Kafka stream successfully stopped"}})
+    {:status 400
+     :body   {:error "No Kafka stream with provided topic-entity exists"}}))
+
+(defn start-stream [topic-entity]
+  (log/debug (str "Starting Kafka stream with topic-entity" topic-entity))
+  (if (get stream-map topic-entity)
+    (do (.start (get stream-map topic-entity))
+        {:status 200
+         :body   {:message "Kafka stream successfully started"}})
+    {:status 400
+     :body   {:error "No Kafka stream with provided topic-entity exists"}}))
 
 (defn stop-streams [streams]
   (log/debug "Stopping Kafka streams")
@@ -262,6 +281,7 @@
                                         (umap/deep-merge default-config-for-stream))
                    stream           (start-stream* topic-handler-fn stream-config topic-entity channels)]
                (.start stream)
+               (conj stream-map {topic-entity stream})
                (conj streams stream)))
            []
            stream-routes)))

--- a/src/ziggurat/streams.clj
+++ b/src/ziggurat/streams.clj
@@ -158,22 +158,13 @@
 (declare stream)
 
 (defn stop-stream [topic-entity]
-  (if (get stream topic-entity)
-    (do (.close (get stream topic-entity))
-        (log/info (str "Stopping Kafka stream with topic-entity " topic-entity)))
-    (log/error "No Kafka stream with provided topic-entity exists")))
-
-(defn start-stream [topic-entity]
-  (log/info KafkaStreams)
   (let [stream (get stream topic-entity)]
     (if stream
       (let [state (.state stream)]
-        (log/info "--------------------------------------------------------------------")
-        (log/info org.apache.kafka.streams.KafkaStreams/values)
-        (if (= state org.apache.kafka.streams.KafkaStreams$State/NOT_RUNNING)
-          (do (.start stream)
-              (log/info (str "Kafka stream with entity " topic-entity " successfully started")))
-          (log/error "Kafka stream already up and running")))
+        (if (= state org.apache.kafka.streams.KafkaStreams$State/RUNNING)
+          (do (.close stream)
+              (log/info (str "Stopping Kafka stream with topic-entity " topic-entity)))
+          (log/error (str "Kafka stream cannot be stopped at the moment, current state is " state))))
       (log/error "No Kafka stream with provided topic-entity exists"))))
 
 (defn stop-streams [streams]

--- a/test/ziggurat/streams_test.clj
+++ b/test/ziggurat/streams_test.clj
@@ -174,7 +174,7 @@
   (poll-to-check-if-running ziggurat.streams/stream)
   (stop-stream :default)
   (is (not= (.state (get ziggurat.streams/stream :default)) KafkaStreams$State/RUNNING))
-  (is (= (.state (get ziggurat.streams/stream :using-string-serde)) KafkaStreams$State/RUNNING)))
+  (is (not= (.state (get ziggurat.streams/stream :using-string-serde)) KafkaStreams$State/NOT_RUNNING)))
 
 (deftest stop-duplicate-stream-test
   (let [message-received-count (atom 0)

--- a/test/ziggurat/streams_test.clj
+++ b/test/ziggurat/streams_test.clj
@@ -1,6 +1,7 @@
 (ns ziggurat.streams-test
   (:require [clojure.test :refer [deftest is join-fixtures testing use-fixtures]]
             [protobuf.core :as proto]
+            [mount.core :as mount]
             [ziggurat.streams :refer [start-streams stop-streams start-stream stop-stream]]
             [ziggurat.fixtures :as fix]
             [ziggurat.config :refer [ziggurat-config]]
@@ -107,6 +108,7 @@
         times                  6
         kvs                    (repeat times message-key-value)
         handler-fn             (default-middleware/protobuf->hash mapped-fn proto-class :default)
+        _                      (mount/start)
         streams                (start-streams {:default {:handler-fn handler-fn}}
                                               (-> (ziggurat-config)
                                                   (assoc-in [:stream-router :default :application-id] (rand-application-id))
@@ -126,6 +128,7 @@
         times                  6
         kvs                    (repeat times message-key-value)
         handler-fn             (default-middleware/protobuf->hash mapped-fn proto-class :default)
+        _                      (mount/start)
         streams                (start-streams {:default {:handler-fn handler-fn}}
                                               (-> (ziggurat-config)
                                                   (assoc-in [:stream-router :default :application-id] (rand-application-id))
@@ -137,7 +140,6 @@
                                                         (MockTime.))
     (Thread/sleep 5000)                                     ;;wating for streams to consume messages
     (stop-stream :default)
-    (start-stream :default)
     (start-stream :default)
     (is (= times @message-received-count))))
 

--- a/test/ziggurat/streams_test.clj
+++ b/test/ziggurat/streams_test.clj
@@ -1,7 +1,7 @@
 (ns ziggurat.streams-test
   (:require [clojure.test :refer [deftest is join-fixtures testing use-fixtures]]
             [protobuf.core :as proto]
-            [ziggurat.streams :refer [start-streams stop-streams]]
+            [ziggurat.streams :refer [start-streams stop-streams start-stream stop-stream]]
             [ziggurat.fixtures :as fix]
             [ziggurat.config :refer [ziggurat-config]]
             [ziggurat.middleware.default :as default-middleware]
@@ -19,7 +19,6 @@
            [io.opentracing.tag Tags]))
 
 (use-fixtures :once (join-fixtures [fix/mount-config-with-tracer
-                                    fix/silence-logging
                                     fix/mount-metrics]))
 
 (defn- props []
@@ -100,6 +99,46 @@
                                                         (MockTime.))
     (Thread/sleep 5000)                                     ;;wating for streams to consume messages
     (stop-streams streams)
+    (is (= times @message-received-count))))
+
+(deftest stop-stream-test
+  (let [message-received-count (atom 0)
+        mapped-fn              (get-mapped-fn message-received-count)
+        times                  6
+        kvs                    (repeat times message-key-value)
+        handler-fn             (default-middleware/protobuf->hash mapped-fn proto-class :default)
+        streams                (start-streams {:default {:handler-fn handler-fn}}
+                                              (-> (ziggurat-config)
+                                                  (assoc-in [:stream-router :default :application-id] (rand-application-id))
+                                                  (assoc-in [:stream-router :default :changelog-topic-replication-factor] changelog-topic-replication-factor)))]
+    (Thread/sleep 10000)                                    ;;waiting for streams to start
+    (IntegrationTestUtils/produceKeyValuesSynchronously (get-in (ziggurat-config) [:stream-router :default :origin-topic])
+                                                        kvs
+                                                        (props)
+                                                        (MockTime.))
+    (Thread/sleep 5000)                                     ;;wating for streams to consume messages
+    (stop-stream :default)
+    (is (= times @message-received-count))))
+
+(deftest start-stream-test
+  (let [message-received-count (atom 0)
+        mapped-fn              (get-mapped-fn message-received-count)
+        times                  6
+        kvs                    (repeat times message-key-value)
+        handler-fn             (default-middleware/protobuf->hash mapped-fn proto-class :default)
+        streams                (start-streams {:default {:handler-fn handler-fn}}
+                                              (-> (ziggurat-config)
+                                                  (assoc-in [:stream-router :default :application-id] (rand-application-id))
+                                                  (assoc-in [:stream-router :default :changelog-topic-replication-factor] changelog-topic-replication-factor)))]
+    (Thread/sleep 10000)                                    ;;waiting for streams to start
+    (IntegrationTestUtils/produceKeyValuesSynchronously (get-in (ziggurat-config) [:stream-router :default :origin-topic])
+                                                        kvs
+                                                        (props)
+                                                        (MockTime.))
+    (Thread/sleep 5000)                                     ;;wating for streams to consume messages
+    (stop-stream :default)
+    (start-stream :default)
+    (start-stream :default)
     (is (= times @message-received-count))))
 
 (deftest start-stream-joins-test

--- a/test/ziggurat/streams_test.clj
+++ b/test/ziggurat/streams_test.clj
@@ -121,7 +121,7 @@
                                                          :stop (fn [] (stop-streams ziggurat.streams/stream))}}))
   (poll-to-check-if-running ziggurat.streams/stream)
   (stop-stream :default)
-  (is (not (= (.state (get ziggurat.streams/stream :default)) KafkaStreams$State/RUNNING))))
+  (is (not= (.state (get ziggurat.streams/stream :default)) KafkaStreams$State/RUNNING)))
 
 (deftest start-stopped-stream-test
   (let [message-received-count (atom 0)
@@ -133,10 +133,10 @@
                                                          :stop (fn [] (stop-streams ziggurat.streams/stream))}}))
   (poll-to-check-if-running ziggurat.streams/stream)
   (stop-stream :default)
-  (is (not (= (.state (get ziggurat.streams/stream :default)) KafkaStreams$State/RUNNING)))
+  (is (not= (.state (get ziggurat.streams/stream :default)) KafkaStreams$State/RUNNING))
   (start-stream :default)
   (poll-to-check-if-running ziggurat.streams/stream)
-  (is (not (= (.state (get ziggurat.streams/stream :default)) KafkaStreams$State/NOT_RUNNING))))
+  (is (not= (.state (get ziggurat.streams/stream :default)) KafkaStreams$State/NOT_RUNNING)))
 
 (deftest stop-restarted-stream-test
   (let [message-received-count (atom 0)
@@ -148,12 +148,12 @@
                                                          :stop (fn [] (stop-streams ziggurat.streams/stream))}}))
   (poll-to-check-if-running ziggurat.streams/stream)
   (stop-stream :default)
-  (is (not (= (.state (get ziggurat.streams/stream :default)) KafkaStreams$State/RUNNING)))
+  (is (not= (.state (get ziggurat.streams/stream :default)) KafkaStreams$State/RUNNING))
   (start-stream :default)
   (poll-to-check-if-running ziggurat.streams/stream :default)
-  (is (not (= (.state (get ziggurat.streams/stream :default)) KafkaStreams$State/NOT_RUNNING)))
+  (is (not= (.state (get ziggurat.streams/stream :default)) KafkaStreams$State/NOT_RUNNING))
   (stop-stream :default)
-  (is (not (= (.state (get ziggurat.streams/stream :default)) KafkaStreams$State/RUNNING))))
+  (is (not= (.state (get ziggurat.streams/stream :default)) KafkaStreams$State/RUNNING)))
 
 (deftest stop-desired-stream-only-test
   (let [message-received-count (atom 0)
@@ -170,7 +170,7 @@
                                                          :stop (fn [] (stop-streams ziggurat.streams/stream))}}))
   (poll-to-check-if-running ziggurat.streams/stream)
   (stop-stream :default)
-  (is (not (= (.state (get ziggurat.streams/stream :default)) KafkaStreams$State/RUNNING)))
+  (is (not= (.state (get ziggurat.streams/stream :default)) KafkaStreams$State/RUNNING))
   (is (= (.state (get ziggurat.streams/stream :using-string-serde)) KafkaStreams$State/RUNNING)))
 
 (deftest stop-duplicate-stream-test
@@ -183,7 +183,7 @@
                                                          :stop (fn [] (stop-streams ziggurat.streams/stream))}}))
   (poll-to-check-if-running ziggurat.streams/stream)
   (stop-stream :default)
-  (is (not (= (.state (get ziggurat.streams/stream :default)) KafkaStreams$State/RUNNING)))
+  (is (not= (.state (get ziggurat.streams/stream :default)) KafkaStreams$State/RUNNING))
   (stop-stream :default))
 
 (deftest stop-invalid-stream-test

--- a/test/ziggurat/streams_test.clj
+++ b/test/ziggurat/streams_test.clj
@@ -21,7 +21,7 @@
            [io.opentracing.tag Tags]))
 
 (use-fixtures :once (join-fixtures [fix/mount-config-with-tracer
-                                    ; fix/silence-logging
+                                    fix/silence-logging
                                     fix/mount-metrics]))
 
 (defn- props []
@@ -118,7 +118,7 @@
         _                      (mount/start)]
     (mount/start-with-states {#'ziggurat.streams/stream {:start (fn [] (start-streams {:default {:handler-fn handler-fn}}
                                                                                       (ziggurat-config)))
-                                                         :stop (fn [] (stop-streams ziggurat.streams/stream))}}))
+                                                         :stop (fn [] (stop-streams #'ziggurat.streams/stream))}}))
   (poll-to-check-if-running ziggurat.streams/stream)
   (stop-stream :default)
   (is (not= (.state (get ziggurat.streams/stream :default)) KafkaStreams$State/RUNNING)))
@@ -206,8 +206,7 @@
         _                      (mount/start)]
     (mount/start-with-states {#'ziggurat.streams/stream {:start (fn [] (start-streams {:default {:handler-fn handler-fn}}
                                                                                       (ziggurat-config)))
-                                                         :stop (fn [] (stop-streams ziggurat.streams/stream))}})
-    (println ziggurat.streams/stream))
+                                                         :stop (fn [] (stop-streams ziggurat.streams/stream))}}))
   (let [is-close-called (atom 0)]
     (with-redefs [mount/start-with-states (fn [] (swap! is-close-called inc))]
       (start-stream :invalid-topic-entity)

--- a/test/ziggurat/streams_test.clj
+++ b/test/ziggurat/streams_test.clj
@@ -20,6 +20,7 @@
            [io.opentracing.tag Tags]))
 
 (use-fixtures :once (join-fixtures [fix/mount-config-with-tracer
+                                    fix/silence-logging
                                     fix/mount-metrics]))
 
 (defn- props []

--- a/test/ziggurat/streams_test.clj
+++ b/test/ziggurat/streams_test.clj
@@ -2,7 +2,7 @@
   (:require [clojure.test :refer [deftest is join-fixtures testing use-fixtures]]
             [protobuf.core :as proto]
             [mount.core :as mount]
-            [ziggurat.streams :refer [start-streams stop-streams start-stream stop-stream]]
+            [ziggurat.streams :refer [start-streams stop-streams stop-stream]]
             [ziggurat.fixtures :as fix]
             [ziggurat.config :refer [ziggurat-config]]
             [ziggurat.middleware.default :as default-middleware]
@@ -120,27 +120,6 @@
                                                         (MockTime.))
     (Thread/sleep 5000)                                     ;;wating for streams to consume messages
     (stop-stream :default)
-    (is (= times @message-received-count))))
-
-(deftest start-stream-test
-  (let [message-received-count (atom 0)
-        mapped-fn              (get-mapped-fn message-received-count)
-        times                  6
-        kvs                    (repeat times message-key-value)
-        handler-fn             (default-middleware/protobuf->hash mapped-fn proto-class :default)
-        _                      (mount/start)
-        streams                (start-streams {:default {:handler-fn handler-fn}}
-                                              (-> (ziggurat-config)
-                                                  (assoc-in [:stream-router :default :application-id] (rand-application-id))
-                                                  (assoc-in [:stream-router :default :changelog-topic-replication-factor] changelog-topic-replication-factor)))]
-    (Thread/sleep 10000)                                    ;;waiting for streams to start
-    (IntegrationTestUtils/produceKeyValuesSynchronously (get-in (ziggurat-config) [:stream-router :default :origin-topic])
-                                                        kvs
-                                                        (props)
-                                                        (MockTime.))
-    (Thread/sleep 5000)                                     ;;wating for streams to consume messages
-    (stop-stream :default)
-    (start-stream :default)
     (is (= times @message-received-count))))
 
 (deftest start-stream-joins-test

--- a/test/ziggurat/streams_test.clj
+++ b/test/ziggurat/streams_test.clj
@@ -65,8 +65,11 @@
   ([stream]
    (poll-to-check-if-running stream :default))
   ([stream topic-entity]
-   (while (not (= (.state (get stream topic-entity)) KafkaStreams$State/RUNNING))
-     (Thread/sleep 2000))))
+   (let [threshold 0]
+     (while (and (not= (.state (get stream topic-entity)) KafkaStreams$State/RUNNING)
+                 (> threshold 30))
+       (Thread/sleep 2000)
+       (inc threshold)))))
 
 (defn- rand-application-id []
   (str "test" "-" (rand-int 999999999)))


### PR DESCRIPTION
Fixes: #56 
- Adds function `stop-stream` and `close-stream` and modifies `stop-streams` function to reuse the code with proper checks before closing.
- Updates the `stream` defstate to store the mapping between topic-entity and stream objects.
- Adds functionality of stopping a stream.