### PR TITLE
[WIP] Moves message-to-process-before-time-threshold logic to middleware

### DIFF
--- a/src/ziggurat/middleware/default.clj
+++ b/src/ziggurat/middleware/default.clj
@@ -48,7 +48,4 @@
     (let [metadata (meta message)]
       (when (message-to-process? (:timestamp metadata) (:oldest-processed-message-in-s default-config-for-stream) )
         (calculate-and-report-kafka-delay (:metric-namespace metadata) (:timestamp metadata) (:additional-tags metadata))
-        (handler-fn (deserialize-message message proto-class topic-entity-name)))
-      (when-not (message-to-process? (:timestamp metadata) (:oldest-processed-message-in-s default-config-for-stream) )
-        (println "************ not processing ******************")
-        (println message)))))
+        (handler-fn (deserialize-message message proto-class topic-entity-name))))))

--- a/src/ziggurat/streams.clj
+++ b/src/ziggurat/streams.clj
@@ -31,7 +31,7 @@
   {:buffered-records-per-partition     10000
    :commit-interval-ms                 15000
    :auto-offset-reset-config           "latest"
-   :oldest-processed-message-in-s      604800
+   :oldest-processed-message-in-s      10
    :changelog-topic-replication-factor 3
    :session-timeout-ms-config          10000
    :consumer-type                      :default

--- a/src/ziggurat/streams.clj
+++ b/src/ziggurat/streams.clj
@@ -31,7 +31,7 @@
   {:buffered-records-per-partition     10000
    :commit-interval-ms                 15000
    :auto-offset-reset-config           "latest"
-   :oldest-processed-message-in-s      10
+   :oldest-processed-message-in-s      604800
    :changelog-topic-replication-factor 3
    :session-timeout-ms-config          10000
    :consumer-type                      :default

--- a/src/ziggurat/timestamp_transformer.clj
+++ b/src/ziggurat/timestamp_transformer.clj
@@ -20,14 +20,13 @@
            ;;(log/debug "stream record metadata--> " "record-key: " record-key " record-value: " record-value " partition: " (.partition processor-context) " topic: " (.topic processor-context))
            (let [message-time     (.timestamp processor-context)
                  partition        (.partition processor-context)
-                 topic            (.topic processor-context)
-                 new-record-value (with-meta 'record-value {:timestamp message-time
-                                                            :topic topic
-                                                            :additional-tags additional-tags
-                                                            :metric-namespace metric-namespace
-                                                            :partition partition})]
-
-             (KeyValue/pair record-key new-record-value)))
+                 topic            (.topic processor-context)]
+             (def ^{:timestamp message-time
+                    :topic topic
+                    :additional-tags additional-tags
+                    :metric-namespace metric-namespace
+                    :partition partition} new-record-value record-value)
+             (KeyValue/pair record-key #'new-record-value)))
          (close [_] nil))
 
 (defn create


### PR DESCRIPTION
- Moves the `message-to-process` function to middleware.
- Edits the message to contain additional data like: `:timestamp`, `:additional-tags`, `:topic`, `:metric-namespace` and `:partition`.
- The middleware returns the deserialized message if it _should_ be processed, else it returns `nil`