### PR TITLE
Removes TODOs related to datadog key removal

### DIFF
--- a/resources/config.test.datadog.only.edn
+++ b/resources/config.test.datadog.only.edn
@@ -1,4 +1,3 @@
-;; TODO: delete this file in the future, :datadog key will be replaced by :statsd key
 {:ziggurat {:datadog {:host    "localhost"
                       :port    [8126 :int]
                       :enabled [true :bool]}}}

--- a/src/ziggurat/config.clj
+++ b/src/ziggurat/config.clj
@@ -12,7 +12,7 @@
 (def config-file "config.edn")
 
 (def default-config {:ziggurat {:nrepl-server         {:port 70171}
-                                :datadog              {:port    8125 ;; TODO: :datadog key will be removed in the future, will be replaced by the :statsd key
+                                :datadog              {:port    8125
                                                        :enabled false}
                                 :sentry               {:enabled                   false
                                                        :worker-count              10
@@ -81,7 +81,7 @@
 
 (defn statsd-config []
   (let [cfg (ziggurat-config)]
-    (get cfg :statsd (:datadog cfg))))                      ;; TODO: remove datadog in the future
+    (get cfg :statsd (:datadog cfg))))
 
 (defn get-in-config
   ([ks]

--- a/src/ziggurat/middleware/default.clj
+++ b/src/ziggurat/middleware/default.clj
@@ -42,7 +42,7 @@
   ([message proto-class topic-entity-name]
    (deserialize-message message proto-class topic-entity-name false))
   ([message proto-class topic-entity-name flatten-protobuf-struct?]
-   (if-not (map? message)                                   ;; TODO: we should have proper dispatch logic per message type (not like this)
+   (if-not (map? message)
      (try
        (let [proto-klass  (protodef/mapdef proto-class)
              loaded-proto (protodef/parse proto-klass message)

--- a/test/ziggurat/config_test.clj
+++ b/test/ziggurat/config_test.clj
@@ -85,7 +85,7 @@
         (mount/start #'config)
         (is (= (:statsd (:ziggurat config-values-from-env)) (statsd-config)))
         (mount/stop))))
-  (testing "returns statsd config using the :datadog key" ;; TODO: remove this test in the future since :datadog key will not be used
+  (testing "returns statsd config using the :datadog key"
     (let [config-filename        "config.test.datadog.only.edn"
           config-values-from-env (config-from-env config-filename)]
       (with-redefs [config-from-env (fn [_] config-values-from-env)


### PR DESCRIPTION
Created an issue for removing the `datadog` key on github here - https://github.com/gojek/ziggurat/issues/197
Thus removing the TODOs related to this work from the codebase. 
Why? Because code is a lousy place to track todos. We can fail to prioritize it, even tend to forget them. With an issue, we can assign it to a milestone. Also, external/new contributors get more visibility into what work they can start picking up.