### PR TITLE
Michael/Hari | Increases the wait time for producer test to 7s

### DIFF
--- a/test/ziggurat/producer_test.clj
+++ b/test/ziggurat/producer_test.clj
@@ -34,7 +34,7 @@
           key          "message"
           value        "Hello World!!"]
       (send :default topic key value)
-      (let [result (IntegrationTestUtils/waitUntilMinKeyValueRecordsReceived *consumer-properties* topic 1 5000)]
+      (let [result (IntegrationTestUtils/waitUntilMinKeyValueRecordsReceived *consumer-properties* topic 1 7000)]
         (is (= value (.value (first result))))))))
 
 (deftest send-data-with-topic-key-partition-and-value-test


### PR DESCRIPTION
The producer test fails in CI for not receiving the message in the given 5000 ms. Increasing it to 7s to see if it fixes the pipeline.