### PR TITLE
Allow handler to directly push message in DLQ

### DIFF
--- a/src/ziggurat/mapper.clj
+++ b/src/ziggurat/mapper.clj
@@ -35,6 +35,7 @@
           retry-metric                        "retry"
           skip-metric                         "skip"
           failure-metric                      "failure"
+          dead-letter-metric                  "dead-letter"
           multi-message-processing-namespaces [message-processing-namespaces [message-processing-namespace]]
           user-payload                        (create-user-payload message-payload)]
       (clog/with-logging-context {:consumer-group topic-entity-name}
@@ -52,6 +53,8 @@
                 :success (metrics/multi-ns-increment-count multi-message-processing-namespaces success-metric additional-tags)
                 :retry (do (metrics/multi-ns-increment-count multi-message-processing-namespaces retry-metric additional-tags)
                            (producer/retry message-payload))
+                :dead-letter (do (metrics/multi-ns-increment-count multi-message-processing-namespaces dead-letter-metric additional-tags)
+                                 (producer/publish-to-dead-queue message-payload))
                 :skip (metrics/multi-ns-increment-count multi-message-processing-namespaces skip-metric additional-tags)
                 :block 'TODO
                 (do

--- a/test/ziggurat/mapper_test.clj
+++ b/test/ziggurat/mapper_test.clj
@@ -87,7 +87,6 @@
                                                              (= additional-tags expected-additional-tags))
                                                     (reset! unsuccessfully-processed? true)))]
             ((mapper-func (constantly :retry) []) message-payload)
-            ((mapper-func (constantly :retry) []) message-payload)
             (let [message-from-mq (rmq/get-msg-from-delay-queue topic-entity)]
               (is (= message-from-mq expected-message)))
             (is @unsuccessfully-processed?)))))

--- a/test/ziggurat/mapper_test.clj
+++ b/test/ziggurat/mapper_test.clj
@@ -87,6 +87,7 @@
                                                              (= additional-tags expected-additional-tags))
                                                     (reset! unsuccessfully-processed? true)))]
             ((mapper-func (constantly :retry) []) message-payload)
+            ((mapper-func (constantly :retry) []) message-payload)
             (let [message-from-mq (rmq/get-msg-from-delay-queue topic-entity)]
               (is (= message-from-mq expected-message)))
             (is @unsuccessfully-processed?)))))
@@ -94,14 +95,14 @@
     (testing "message process should be unsuccessful and be pushed to dlq"
       (fix/with-queues stream-routes
         (let [unsuccessfully-processed? (atom false)
-             expected-metric           "dead-letter"]
+              expected-metric           "dead-letter"]
 
           (with-redefs [metrics/increment-count (fn [metric-namespace metric additional-tags]
                                                   (when (and (or (= metric-namespace [service-name topic-entity expected-metric-namespace])
                                                                  (= metric-namespace [expected-metric-namespace]))
                                                              (= metric expected-metric)
                                                              (= additional-tags expected-additional-tags))
-                                                        (reset! unsuccessfully-processed? true)))]
+                                                    (reset! unsuccessfully-processed? true)))]
             ((mapper-func (constantly :dead-letter) []) message-payload)
             (let [message-from-mq (rmq/get-msg-from-dead-queue topic-entity)]
               (is (= message-payload message-from-mq)))


### PR DESCRIPTION
This will provide a mechanism to push erroneous messages into DLQ without retries