### PR TITLE
Add dead letter queue to channel-mapper-func

### DIFF
--- a/src/ziggurat/mapper.clj
+++ b/src/ziggurat/mapper.clj
@@ -79,6 +79,7 @@
           retry-metric                        "retry"
           skip-metric                         "skip"
           failure-metric                      "failure"
+          dead-letter-metric                  "dead-letter"
           multi-message-processing-namespaces [message-processing-namespaces [message-processing-namespace]]
           user-payload                        (create-user-payload message-payload)]
       (clog/with-logging-context {:consumer-group topic-entity-name :channel channel-name}
@@ -96,6 +97,8 @@
                 :success (metrics/multi-ns-increment-count multi-message-processing-namespaces success-metric additional-tags)
                 :retry (do (metrics/multi-ns-increment-count multi-message-processing-namespaces retry-metric additional-tags)
                            (producer/retry-for-channel message-payload channel))
+                :dead-letter (do (metrics/multi-ns-increment-count multi-message-processing-namespaces dead-letter-metric additional-tags)
+                                 (producer/publish-to-channel-dead-queue channel message-payload))
                 :skip (metrics/multi-ns-increment-count multi-message-processing-namespaces skip-metric additional-tags)
                 :block 'TODO
                 (throw (ex-info "Invalid mapper return code" {:code return-code}))))


### PR DESCRIPTION
This was missed out in https://github.com/gojek/ziggurat/pull/245.