### PR TITLE
Fix delete deadset messages logic

### DIFF
--- a/src/ziggurat/messaging/consumer.clj
+++ b/src/ziggurat/messaging/consumer.clj
@@ -102,7 +102,6 @@
                 (when (some? payload)
                   (process-message-from-queue ch meta payload topic-entity processing-fn))))))))
 
-
 (defn delete-dead-set-messages
   "This method deletes `count` number of messages from RabbitMQ dead-letter queue for topic `topic-entity` and channel
   `channel`."

--- a/src/ziggurat/messaging/consumer.clj
+++ b/src/ziggurat/messaging/consumer.clj
@@ -102,6 +102,16 @@
                 (when (some? payload)
                   (process-message-from-queue ch meta payload topic-entity processing-fn))))))))
 
+
+(defn delete-dead-set-messages
+  "This method deletes `count` number of messages from RabbitMQ dead-letter queue for topic `topic-entity` and channel
+  `channel`."
+  [topic-entity channel count]
+  (with-open [ch (lch/open connection)]
+    (let [queue-name (construct-queue-name topic-entity channel)]
+      (doall (for [_ (range count)]
+               (lb/get ch queue-name true))))))
+
 (defn- message-handler [wrapped-mapper-fn topic-entity]
   (fn [ch meta ^bytes payload]
     (clog/with-logging-context {:consumer-group topic-entity} (process-message-from-queue ch meta payload topic-entity wrapped-mapper-fn))))

--- a/src/ziggurat/messaging/dead_set.clj
+++ b/src/ziggurat/messaging/dead_set.clj
@@ -25,5 +25,5 @@
   "Deletes n number of messages from dead queue"
   [count-of-message topic-entity channel]
   (log/debugf "Deleting %d number of messages from dead-letter-queue for topic [%s] and channel [%s]", count-of-message, topic-entity, channel)
-  (consumer/process-dead-set-messages topic-entity channel count-of-message (fn [message-payload])))
+  (consumer/delete-dead-set-messages topic-entity channel count-of-message))
 

--- a/test/ziggurat/messaging/consumer_test.clj
+++ b/test/ziggurat/messaging/consumer_test.clj
@@ -51,6 +51,16 @@
           (is (= count @process-fn-called))
           (is (empty? (consumer/get-dead-set-messages topic-entity channel count))))))))
 
+(deftest delete-dead-set-messages-test
+  (let [message-payload (assoc (gen-message-payload topic-entity) :retry-count 0)]
+    (testing "it deletes messages for a specified count and topic-entity"
+      (fix/with-queues {topic-entity {:handler-fn (constantly nil)}}
+                       (let [count 5]
+                         (doseq [_ (range count)]
+                           (producer/publish-to-dead-queue message-payload))
+                         (consumer/delete-dead-set-messages topic-entity nil count)
+                         (is (empty? (consumer/get-dead-set-messages topic-entity nil count))))))))
+
 (deftest get-dead-set-messages-test
   (let [message-payload (assoc (gen-message-payload topic-entity) :retry-count 0)]
     (testing "get the dead set messages from dead set queue and don't pop the messages from the queue"

--- a/test/ziggurat/messaging/consumer_test.clj
+++ b/test/ziggurat/messaging/consumer_test.clj
@@ -55,11 +55,18 @@
   (let [message-payload (assoc (gen-message-payload topic-entity) :retry-count 0)]
     (testing "it deletes messages for a specified count and topic-entity"
       (fix/with-queues {topic-entity {:handler-fn (constantly nil)}}
-                       (let [count 5]
-                         (doseq [_ (range count)]
-                           (producer/publish-to-dead-queue message-payload))
-                         (consumer/delete-dead-set-messages topic-entity nil count)
-                         (is (empty? (consumer/get-dead-set-messages topic-entity nil count))))))))
+        (let [count 5]
+          (doseq [_ (range count)]
+            (producer/publish-to-dead-queue message-payload))
+          (consumer/delete-dead-set-messages topic-entity nil count)
+          (is (empty? (consumer/get-dead-set-messages topic-entity count))))))
+    (testing "it deletes messages for a specified count, topic-entity and channel"
+      (fix/with-queues {topic-entity {:handler-fn (constantly nil) :channel-1 (constantly nil)}}
+        (let [count 5]
+          (doseq [_ (range count)]
+            (producer/publish-to-channel-dead-queue :channel-1 message-payload))
+          (consumer/delete-dead-set-messages topic-entity :channel-1 count)
+          (is (empty? (consumer/get-dead-set-messages topic-entity :channel-1 count))))))))
 
 (deftest get-dead-set-messages-test
   (let [message-payload (assoc (gen-message-payload topic-entity) :retry-count 0)]


### PR DESCRIPTION
Improve the logic to delete deadset messages. Do not parse the messages as messages created using different version of Ziggurat can cause error while parsing.