### PR TITLE
Publish message to the right deadset using the common publish methods

### DIFF
--- a/src/ziggurat/messaging/consumer.clj
+++ b/src/ziggurat/messaging/consumer.clj
@@ -28,8 +28,8 @@
 (defn- publish-to-dead-set-and-ack
   [ch delivery-tag payload ziggurat-channel-key]
   (if (nil? ziggurat-channel-key)
-                    (producer/publish-to-dead-queue payload)
-                    (producer/publish-to-channel-dead-queue ziggurat-channel-key payload))
+    (producer/publish-to-dead-queue payload)
+    (producer/publish-to-channel-dead-queue ziggurat-channel-key payload))
   (ack-message ch delivery-tag))
 
 (defn convert-and-ack-message
@@ -46,8 +46,6 @@
       (metrics/increment-count ["rabbitmq-message" "conversion"] "failure" {:topic_name (name topic-entity)})
       (publish-to-dead-set-and-ack ch delivery-tag payload ziggurat-channel-key)
       nil)))
-
-
 
 (defn process-message-from-queue [ch meta payload topic-entity processing-fn ziggurat-channel-key]
   (let [delivery-tag    (:delivery-tag meta)

--- a/src/ziggurat/messaging/producer.clj
+++ b/src/ziggurat/messaging/producer.clj
@@ -105,11 +105,20 @@
 
 (defn publish
   "This is meant for publishing to rabbitmq.
+  * Supports publishing both serialized and deserialized messages. If is-payload-serialized is true, the message won't be
+  frozen before publishing to rabbitmq, else it would be frozen via nippy.
+  * Use case(s) of sending serialized-payloads
+    1) If a subscriber encounters an exception, while deserializing the message it receives from instant queue,
+    the serialized payload
+    is sent as is to the dead-letter-queue.
+    2) If a subscriber encounters any exception while processing the message, the serialized payload
+    is sent as is to the dead-letter-queue
   * Checks if the pool is alive - We do this so that publish does not happen after the channel pool state is stopped.
   * publish-internal returns multiple states
     * :success - Message has been successfully produced to rabbitmq
     * :retry - A retryable exception was encountered and message will be retried until it is successfully published.
-    * :retry-with-counter - A non recoverable exception is encountered, but the message will be retried for a few times. defined by the counter
+    * :retry-with-counter - A non recoverable exception is encountered, but the message will be retried for a few times.
+    defined by the counter
       { :rabbit-mq-connection { :publish-retry { :non-recoverable-exception {:count}}}}}"
   ([exchange message-payload]
    (publish exchange message-payload nil))

--- a/test/ziggurat/messaging/consumer_test.clj
+++ b/test/ziggurat/messaging/consumer_test.clj
@@ -297,7 +297,7 @@
           (let [queue-name          (get-in (rabbitmq-config) [:dead-letter :queue-name])
                 prefixed-queue-name (str topic-entity-name "_" queue-name)
                 [meta payload]      (lb/get ch prefixed-queue-name false)
-                _                   (consumer/process-message-from-queue ch meta payload topic-entity processing-fn)
+                _                   (consumer/process-message-from-queue ch meta payload topic-entity processing-fn nil)
                 consumed-message    (util/get-msg-from-dead-queue-without-ack topic-entity-name)]
             (is (= consumed-message nil)))))))
   (testing "process-message function not process a message if convert-message returns nil"
@@ -314,7 +314,7 @@
             (let [queue-name          (get-in (rabbitmq-config) [:dead-letter :queue-name])
                   prefixed-queue-name (str topic-entity-name "_" queue-name)
                   [meta payload]      (lb/get ch prefixed-queue-name false)
-                  _                   (consumer/process-message-from-queue ch meta payload topic-entity processing-fn)
+                  _                   (consumer/process-message-from-queue ch meta payload topic-entity processing-fn nil)
                   consumed-message    (util/get-msg-from-dead-queue-without-ack topic-entity-name)]
               (is (= false @processing-fn-called))
               (is (= consumed-message nil))))))))
@@ -332,7 +332,7 @@
             (let [queue-name          (get-in (rabbitmq-config) [:dead-letter :queue-name])
                   prefixed-queue-name (str topic-entity-name "_" queue-name)
                   [meta payload]      (lb/get ch prefixed-queue-name false)
-                  _                   (consumer/process-message-from-queue ch meta payload topic-entity processing-fn)
+                  _                   (consumer/process-message-from-queue ch meta payload topic-entity processing-fn nil)
                   consumed-message    (util/get-msg-from-dead-queue-without-ack topic-entity-name)]
               (is (= consumed-message message))
               (is @report-fn-called?))))))))
@@ -348,7 +348,7 @@
                                  (is (= exchange expected-exchange))
                                  (is (= freezed-message payload))
                                  (reset! is-publish-called? true))]
-        (consumer/convert-and-ack-message nil {:delivery-tag "delivery-tag"} freezed-message false topic-entity))
+        (consumer/convert-and-ack-message nil {:delivery-tag "delivery-tag"} freezed-message false topic-entity nil))
       (is (= @is-publish-called? true))))
   (testing "should call reject when both nippy/thaw and lb/publish throws an exception"
     (let [freezed-message   (nippy/freeze {:foo "bar"})
@@ -358,5 +358,5 @@
                                               (throw (Exception. "lb/publish exception")))
                     consumer/reject-message (fn [_ _]
                                               (reset! is-reject-called? true))]
-        (consumer/convert-and-ack-message nil {:delivery-tag "delivery-tag"} freezed-message false "default"))
+        (consumer/convert-and-ack-message nil {:delivery-tag "delivery-tag"} freezed-message false "default" nil))
       (is (= @is-reject-called? true)))))

--- a/test/ziggurat/util/rabbitmq.clj
+++ b/test/ziggurat/util/rabbitmq.clj
@@ -17,7 +17,7 @@
     (try
       (let [[meta payload] (lb/get ch queue-name false)]
         (when (seq payload)
-          (consumer/convert-and-ack-message ch meta payload true (keyword topic-name))))
+          (consumer/convert-and-ack-message ch meta payload true (keyword topic-name) nil)))
       (catch NullPointerException e
         nil))))
 
@@ -26,7 +26,7 @@
     (try
       (let [[meta payload] (lb/get ch queue-name false)]
         (when (seq payload)
-          (consumer/convert-and-ack-message ch meta payload false (keyword topic-name))))
+          (consumer/convert-and-ack-message ch meta payload false (keyword topic-name) nil)))
       (catch NullPointerException e
         nil))))
 


### PR DESCRIPTION
- Introduced support for publishing serialized payload to dead-letter-queue.
- Modified consumption layer to use common deadset publishing methods to publish to dead-letter-queue.
    -  Both convert-and-ack, and process-message-from-queue, utilize this common layer.
