### PR TITLE
fix retry count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 All notable changes to this project will be documented in this file. This change log follows the conventions
 of [keepachangelog.com](http://keepachangelog.com/).
 
+## 4.10.2
+- Fix retry-count returning nil if empty. Returns 0 by default now.
 ## 4.10.0
 - Adds Native Prometheus client integration
 

--- a/bin/run_cluster_tests_in_ci.sh
+++ b/bin/run_cluster_tests_in_ci.sh
@@ -3,4 +3,4 @@
 set -ex
 
 lein clean
-sudo make test-cluster
+make test-cluster

--- a/bin/run_cluster_tests_in_ci.sh
+++ b/bin/run_cluster_tests_in_ci.sh
@@ -3,4 +3,4 @@
 set -ex
 
 lein clean
-make test-cluster
+sudo make test-cluster

--- a/project.clj
+++ b/project.clj
@@ -2,7 +2,7 @@
 (cemerick.pomegranate.aether/register-wagon-factory!
   "http" #(org.apache.maven.wagon.providers.http.HttpWagon.))
 
-(defproject tech.gojek/ziggurat "4.10.1"
+(defproject tech.gojek/ziggurat "4.10.2"
   :description "A stream processing framework to build stateless applications on kafka"
   :url "https://github.com/gojektech/ziggurat"
   :license {:name "Apache License, Version 2.0"

--- a/src/ziggurat/mapper.clj
+++ b/src/ziggurat/mapper.clj
@@ -17,7 +17,8 @@
 
 (defn- create-user-payload
   [message-payload configured-retry-count]
-  (let [remaining-retry-count (get message-payload :retry-count configured-retry-count)]
+  (let [configured-retry-count (or configured-retry-count 0)
+        remaining-retry-count (get message-payload :retry-count configured-retry-count)]
     (-> message-payload
         (dissoc :headers)
         (dissoc :retry-count)

--- a/test/ziggurat/mapper_test.clj
+++ b/test/ziggurat/mapper_test.clj
@@ -329,9 +329,9 @@
                              :metadata     metadata}
             user-handler-fn (fn [user-msg-payload]
                               (reset! user-handler-called true)
-                              (is (= ((get user-msg-payload :metadata) :rabbitmq-retry-count ) 0)))]
+                              (is (= ((get user-msg-payload :metadata) :rabbitmq-retry-count) 0)))]
         (with-redefs [metrics/increment-count (constantly nil)
-                         get-channel-retry-count (constantly nil) ]
+                      get-channel-retry-count (constantly nil)]
           ((channel-mapper-func user-handler-fn channel) message-payload)
           (is @user-handler-called))))))
 

--- a/test/ziggurat/mapper_test.clj
+++ b/test/ziggurat/mapper_test.clj
@@ -323,15 +323,15 @@
           ((channel-mapper-func user-handler-fn channel)  message-payload)
           (is @user-handler-called))))
     (testing "retry-count set to nil returns rabbitmq-retry-count 0"
-         (let [user-handler-called (atom false)
-               message-payload {:retry-count 0
-                                :topic-entity topic
-                                :metadata     metadata}
-               user-handler-fn (fn [user-msg-payload]
-                                 (reset! user-handler-called true)
-                                 (is (= ((get user-msg-payload :metadata) :rabbitmq-retry-count ) 0)))]
-           (with-redefs [metrics/increment-count (constantly nil)
+      (let [user-handler-called (atom false)
+            message-payload {:retry-count 0
+                             :topic-entity topic
+                             :metadata     metadata}
+            user-handler-fn (fn [user-msg-payload]
+                              (reset! user-handler-called true)
+                              (is (= ((get user-msg-payload :metadata) :rabbitmq-retry-count ) 0)))]
+        (with-redefs [metrics/increment-count (constantly nil)
                          get-channel-retry-count (constantly nil) ]
-             ((channel-mapper-func user-handler-fn channel) message-payload)
-             (is @user-handler-called))))))
+          ((channel-mapper-func user-handler-fn channel) message-payload)
+          (is @user-handler-called))))))
 


### PR DESCRIPTION
Returning a default value of 0 when retry-count is null during channel based setup without channel retry.