### PR TITLE
Fix shutdown race condition to avoid double processing and unnecessary dead-set publishes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this project will be documented in this file. This change log follows the conventions
 of [keepachangelog.com](http://keepachangelog.com/).
 
+## 4.12.1
+- Drain in-flight RabbitMQ messages on shutdown to prevent double processing
+
 ## 4.12.0
 - Adds support for ACL auth for kafka streams.
 

--- a/project.clj
+++ b/project.clj
@@ -2,7 +2,7 @@
 (cemerick.pomegranate.aether/register-wagon-factory!
   "http" #(org.apache.maven.wagon.providers.http.HttpWagon.))
 
-(defproject tech.gojek/ziggurat "4.12.0"
+(defproject tech.gojek/ziggurat "4.12.1"
   :description "A stream processing framework to build stateless applications on kafka"
   :url "https://github.com/gojektech/ziggurat"
   :license {:name "Apache License, Version 2.0"

--- a/src/ziggurat/init.clj
+++ b/src/ziggurat/init.clj
@@ -178,8 +178,8 @@
 (defn- add-shutdown-hook [actor-stop-fn modes]
   (.addShutdownHook
    (Runtime/getRuntime)
-   (Thread. ^Runnable #((stop actor-stop-fn modes)
-                        (shutdown-agents))
+   (Thread. ^Runnable #(do (stop actor-stop-fn modes)
+                           (shutdown-agents))
             "Shutdown-handler")))
 
 (declare StreamRoute)

--- a/src/ziggurat/messaging/consumer.clj
+++ b/src/ziggurat/messaging/consumer.clj
@@ -18,6 +18,9 @@
 
 (def DEFAULT_CHANNEL_PREFETCH_COUNT 20)
 
+(def ^:private in-flight-count (atom 0))
+(def DEFAULT_SHUTDOWN_DRAIN_TIMEOUT_MS 5000)
+
 (defn- ack-message
   [ch delivery-tag]
   (lb/ack ch delivery-tag))
@@ -49,6 +52,7 @@
         message-payload (convert-and-ack-message ch meta payload false topic-entity ziggurat-channel-key)]
     (when message-payload
       (log/infof "Processing message [%s] from RabbitMQ " message-payload)
+      (swap! in-flight-count inc)
       (try
         (log/debug "Calling processor-fn with the message-payload - " message-payload " with retry count - " (:retry-count message-payload))
         (processing-fn message-payload)
@@ -56,7 +60,9 @@
         (catch Exception e
           (report-error e "Error while processing message-payload from RabbitMQ")
           (metrics/increment-count ["rabbitmq-message" "process"] "failure" {:topic_name (name topic-entity)})
-          (publish-serialized-payload-to-dead-set-and-ack ch delivery-tag payload topic-entity ziggurat-channel-key))))))
+          (publish-serialized-payload-to-dead-set-and-ack ch delivery-tag payload topic-entity ziggurat-channel-key))
+        (finally
+          (swap! in-flight-count dec))))))
 
 (defn read-message-from-queue [ch queue-name topic-entity ack? ziggurat-channel-key]
   (try
@@ -201,6 +207,26 @@
           _ (log/debug "Subscriber info" data)]
       data)))
 
+(defn wait-for-in-flight-messages
+  "Waits until all in-flight messages finish processing, or until timeout-ms elapses.
+   This should be called after canceling subscriptions but before closing connections,
+   to ensure in-flight message handlers complete and can ack/publish before channels are torn down."
+  ([]
+   (wait-for-in-flight-messages (get-in-config [:shutdown :drain-timeout-ms] DEFAULT_SHUTDOWN_DRAIN_TIMEOUT_MS)))
+  ([timeout-ms]
+   (let [start-time (System/currentTimeMillis)]
+     (loop []
+       (let [current-count @in-flight-count
+             elapsed       (- (System/currentTimeMillis) start-time)]
+         (when (and (pos? current-count) (< elapsed timeout-ms))
+           (log/infof "Waiting for %d in-flight message(s) to complete (%dms elapsed)..." current-count elapsed)
+           (Thread/sleep (min 100 (- timeout-ms elapsed)))
+           (recur))))
+     (let [remaining @in-flight-count]
+       (if (pos? remaining)
+         (log/warnf "Timed out waiting for %d in-flight message(s) to complete after %dms" remaining timeout-ms)
+         (log/info "All in-flight messages completed"))))))
+
 (defn stop-subscribers [subscribers additional-message]
   (doseq [{:keys [rabbitmq-channel consumer-tag]} subscribers]
     (log/infof "Stopping consumer with tag %s for %s", consumer-tag, additional-message)
@@ -235,5 +261,6 @@
             (when (contains? consumers :stream-consumers)
               (stop-subscribers-for-consumers (:stream-consumers consumers)))
             (when (contains? consumers :batch-consumers)
-              (stop-subscribers-for-consumers (:batch-consumers consumers))))))
+              (stop-subscribers-for-consumers (:batch-consumers consumers))))
+          (wait-for-in-flight-messages)))
 

--- a/test/ziggurat/messaging/consumer_test.clj
+++ b/test/ziggurat/messaging/consumer_test.clj
@@ -17,6 +17,11 @@
 (use-fixtures :once (join-fixtures [fix/init-rabbit-mq
                                     fix/silence-logging
                                     fix/mount-metrics]))
+
+(use-fixtures :each (fn [f]
+                      (reset! @#'consumer/in-flight-count 0)
+                      (f)))
+
 (defn- gen-message-payload [topic-entity]
   {:message      {:gen-key (apply str (take 10 (repeatedly #(char (+ (rand 26) 65)))))}
    :topic-entity topic-entity})
@@ -331,3 +336,91 @@
         (consumer/convert-and-ack-message nil {:delivery-tag "delivery-tag"} freezed-message false topic-entity nil))
       (is (= @is-publish-called? true))
       (is (= @is-message-acked? true)))))
+
+(deftest in-flight-message-tracking-test
+  (testing "in-flight count should be zero before and after processing"
+    (fix/with-queues {topic-entity {:handler-fn #(constantly nil)}}
+      (let [message            (gen-message-payload topic-entity)
+            in-flight-during   (atom nil)
+            processing-fn      (fn [_]
+                                 (reset! in-flight-during @@#'consumer/in-flight-count))
+            topic-entity-name  (name topic-entity)]
+        (is (= 0 @@#'consumer/in-flight-count))
+        (producer/publish-to-dead-queue message)
+        (with-open [ch (lch/open consumer-connection)]
+          (let [queue-name          (get-in (rabbitmq-config) [:dead-letter :queue-name])
+                prefixed-queue-name (str topic-entity-name "_" queue-name)
+                [meta payload]      (lb/get ch prefixed-queue-name false)]
+            (consumer/process-message-from-queue ch meta payload topic-entity processing-fn nil)))
+        (is (= 1 @in-flight-during))
+        (is (= 0 @@#'consumer/in-flight-count)))))
+
+  (testing "in-flight count should return to zero even when processing throws"
+    (fix/with-queues {topic-entity {:handler-fn #(constantly nil)}}
+      (let [message            (gen-message-payload topic-entity)
+            failure-handled?   (atom false)
+            processing-fn      (fn [_] (throw (Exception. "processing error")))
+            topic-entity-name  (name topic-entity)]
+        (is (= 0 @@#'consumer/in-flight-count))
+        (producer/publish-to-dead-queue message)
+        (with-open [ch (lch/open consumer-connection)]
+          (let [queue-name          (get-in (rabbitmq-config) [:dead-letter :queue-name])
+                prefixed-queue-name (str topic-entity-name "_" queue-name)
+                [meta payload]      (lb/get ch prefixed-queue-name false)]
+            (with-redefs [report-error (fn [_ _] (reset! failure-handled? true))]
+              (consumer/process-message-from-queue ch meta payload topic-entity processing-fn nil))))
+        (is (true? @failure-handled?) "the processing-failure path should have executed")
+        (is (= 0 @@#'consumer/in-flight-count))))))
+
+(deftest wait-for-in-flight-messages-test
+  (testing "should return immediately when no messages are in-flight"
+    (reset! @#'consumer/in-flight-count 0)
+    (let [start-time (System/currentTimeMillis)]
+      (consumer/wait-for-in-flight-messages 1000)
+      (is (< (- (System/currentTimeMillis) start-time) 500))))
+
+  (testing "should wait until in-flight messages complete"
+    (reset! @#'consumer/in-flight-count 1)
+    (let [wait-future (future (consumer/wait-for-in-flight-messages 5000))]
+      (Thread/sleep 200)
+      (reset! @#'consumer/in-flight-count 0)
+      (let [result (deref wait-future 3000 :timeout)]
+        (is (not= :timeout result)))))
+
+  (testing "should time out if messages don't complete within timeout"
+    (reset! @#'consumer/in-flight-count 1)
+    (let [start-time (System/currentTimeMillis)]
+      (consumer/wait-for-in-flight-messages 500)
+      (let [elapsed (- (System/currentTimeMillis) start-time)]
+        (is (>= elapsed 400))
+        (is (< elapsed 2000))))
+    (reset! @#'consumer/in-flight-count 0))
+
+  (testing "the zero-arity version reads the drain timeout from config"
+    (reset! @#'consumer/in-flight-count 1)
+    (with-redefs [ziggurat.config/get-in-config (fn
+                                                  ([ks] (get-in (ziggurat-config) ks))
+                                                  ([ks _default]
+                                                   (if (= ks [:shutdown :drain-timeout-ms])
+                                                     250
+                                                     (get-in (ziggurat-config) ks))))]
+      (let [start-time (System/currentTimeMillis)]
+        (consumer/wait-for-in-flight-messages)
+        (let [elapsed (- (System/currentTimeMillis) start-time)]
+          (is (>= elapsed 200) "should honour the configured drain timeout")
+          (is (< elapsed 1500) "should not wait beyond the configured drain timeout"))))
+    (reset! @#'consumer/in-flight-count 0)))
+
+(deftest consumers-stop-drains-in-flight-messages-test
+  (testing "stopping the consumers state cancels subscribers and then drains in-flight messages"
+    (let [events (atom [])]
+      (with-redefs [consumer/start-subscribers              (fn [_ _] {:stream-consumers {} :batch-consumers {}})
+                    consumer/stop-subscribers-for-consumers (fn [_] (swap! events conj :stopped-subscribers))
+                    consumer/wait-for-in-flight-messages    (fn
+                                                              ([] (swap! events conj :drained))
+                                                              ([_] (swap! events conj :drained)))]
+        (mount/start #'consumer/consumers)
+        (mount/stop #'consumer/consumers)
+        (is (= :drained (last @events)) "draining must happen during stop")
+        (is (= [:stopped-subscribers :stopped-subscribers :drained] @events)
+            "subscribers must be cancelled before in-flight messages are drained")))))


### PR DESCRIPTION
During shutdown, consumer connections could be torn down while messages were
still being processed, leaving those messages unacked. RabbitMQ then redelivered
them, causing the same messages to be processed again after restart.

Track in-flight messages with a counter (incremented before processing and
decremented in a finally block) and, when stopping the consumers, wait for the
in-flight handlers to finish after cancelling subscriptions but before the
connection is closed. The wait is bounded by a configurable drain timeout
([:shutdown :drain-timeout-ms], default 5000ms).

Also fix the JVM shutdown hook to run (stop ...) and (shutdown-agents)
sequentially via do; previously it invoked the result of stop as a function.

Adds tests covering in-flight tracking, wait-for-in-flight-messages (including
the configured-timeout path), and the drain step in the consumers :stop lifecycle.