### PR TITLE
Feature : Add manual offset commit option for batch consumers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file. This change log follows the conventions
 of [keepachangelog.com](http://keepachangelog.com/).
 
-## 4.13.0
+## 4.12.2
 - Adds `:manual-commit-enabled` config flag for batch routes. When enabled, Kafka auto-commit is disabled and offsets are committed only after a batch has been processed, guaranteeing at-least-once delivery and preventing message loss. Defaults to `false` (existing auto-commit behaviour).
 
 ## 4.12.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this project will be documented in this file. This change log follows the conventions
 of [keepachangelog.com](http://keepachangelog.com/).
 
+## 4.13.0
+- Adds `:manual-commit-enabled` config flag for batch routes. When enabled, Kafka auto-commit is disabled and offsets are committed only after a batch has been processed, guaranteeing at-least-once delivery and preventing message loss. Defaults to `false` (existing auto-commit behaviour).
+
 ## 4.12.1
 - Drain in-flight RabbitMQ messages on shutdown to prevent double processing
 

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -157,6 +157,7 @@ All Ziggurat configs should be in your `clonfig` `config.edn` under the `:ziggur
 | `:consumer-group-id`                | String    | Yes       | Consumer group ID for the batch route.          |
 | `:bootstrap-servers`                | String    | Yes       | Kafka bootstrap servers for the batch route.    |
 | `:origin-topic`                     | String    | Yes       | Origin topic for the batch route.               |
+| `:manual-commit-enabled`            | Boolean   | No        | When `true`, disables Kafka auto-commit and commits offsets only after a batch is processed (at-least-once, prevents message loss). Defaults to `false` (auto-commit). |
 
 ## SSL
 

--- a/doc/kafka_produce_consume.md
+++ b/doc/kafka_produce_consume.md
@@ -87,4 +87,18 @@ Ziggurat Config | Default Value | Description | Mandatory?
 :poll-timeout-ms-config | 1000 | [Timeout value used for polling with a Kafka Consumer](https://github.com/apache/kafka/blob/trunk/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java#L1160) | No
 :thread-count | 2 | Number of Kafka Consumer threads for each batch-route | No
 :default-api-timeout-ms | 60000 | [https://cwiki.apache.org/confluence/display/KAFKA/KIP-266%3A+Fix+consumer+indefinite+blocking+behavior](https://cwiki.apache.org/confluence/display/KAFKA/KIP-266%3A+Fix+consumer+indefinite+blocking+behavior) | No
+:manual-commit-enabled | false | When `true`, Kafka's background auto-commit (`enable.auto.commit`) is disabled and offsets are committed (`commitSync`) only after a batch has been processed and any failures enqueued for retry. This guarantees at-least-once delivery and prevents message loss when a consumer dies mid-batch. When `false` (default), the existing auto-commit behaviour is preserved. | No
+
+#### Offset commit semantics for batch consumers
+
+By default (`:manual-commit-enabled false`) batch consumers rely on Kafka's auto-commit
+(`enable.auto.commit=true`), which commits offsets on a timer independently of batch
+processing. If a consumer dies after offsets are auto-committed but before a batch finishes
+processing, those messages can be lost.
+
+Setting `:manual-commit-enabled true` on a batch route turns off auto-commit and makes
+Ziggurat commit offsets with `commitSync` only after the batch handler has run and any
+messages needing retry have been enqueued to RabbitMQ. A failed commit is logged and reported
+via the `ziggurat.batch.consumption.offset.commit` metric but does not halt the poll loop —
+the offsets are committed on the next successful commit, preserving at-least-once delivery.
 

--- a/project.clj
+++ b/project.clj
@@ -2,7 +2,7 @@
 (cemerick.pomegranate.aether/register-wagon-factory!
   "http" #(org.apache.maven.wagon.providers.http.HttpWagon.))
 
-(defproject tech.gojek/ziggurat "4.13.0"
+(defproject tech.gojek/ziggurat "4.12.2"
   :description "A stream processing framework to build stateless applications on kafka"
   :url "https://github.com/gojektech/ziggurat"
   :license {:name "Apache License, Version 2.0"

--- a/project.clj
+++ b/project.clj
@@ -2,7 +2,7 @@
 (cemerick.pomegranate.aether/register-wagon-factory!
   "http" #(org.apache.maven.wagon.providers.http.HttpWagon.))
 
-(defproject tech.gojek/ziggurat "4.12.1"
+(defproject tech.gojek/ziggurat "4.13.0"
   :description "A stream processing framework to build stateless applications on kafka"
   :url "https://github.com/gojektech/ziggurat"
   :license {:name "Apache License, Version 2.0"

--- a/resources/config.test.edn
+++ b/resources/config.test.edn
@@ -85,6 +85,7 @@
                                                 :bootstrap-servers               "localhost:9092"
                                                 :max-poll-records                [2000 :int]
                                                 :origin-topic                    "topic"
+                                                :manual-commit-enabled           [true :bool]
                                                 :poll-timeout-ms-config          [1000 :int]
                                                 :thread-count                    [4 :int]
                                                 :session-timeout-ms-config       [60000 :int]

--- a/src/ziggurat/config.clj
+++ b/src/ziggurat/config.clj
@@ -170,6 +170,7 @@
    :producer
    :thread-count
    :enabled
+   :manual-commit-enabled
    :jaas])
 
 (defn- not-blank?

--- a/src/ziggurat/kafka_consumer/consumer.clj
+++ b/src/ziggurat/kafka_consumer/consumer.clj
@@ -13,10 +13,21 @@
    :key-deserializer-class-config   "org.apache.kafka.common.serialization.ByteArrayDeserializer"
    :value-deserializer-class-config "org.apache.kafka.common.serialization.ByteArrayDeserializer"})
 
+(defn- with-manual-commit-config
+  "When `:manual-commit-enabled` is set on the batch route, Kafka's background auto-commit
+   is turned off so offsets are committed by the consumer-handler only after a batch has
+   been processed. Without the flag the config is returned unchanged, preserving the
+   existing auto-commit behaviour."
+  [consumer-config]
+  (cond-> consumer-config
+    (:manual-commit-enabled consumer-config) (assoc :enable-auto-commit false)))
+
 (defn create-consumer
   [topic-entity consumer-group-config]
   (try
-    (let [merged-consumer-group-config (umap/deep-merge consumer-group-config default-consumer-config)
+    (let [merged-consumer-group-config (-> consumer-group-config
+                                           (umap/deep-merge default-consumer-config)
+                                           (with-manual-commit-config))
           consumer                     (KafkaConsumer.
                                         (cfg/build-consumer-config-properties merged-consumer-group-config))
           topic-pattern                (Pattern/compile (:origin-topic merged-consumer-group-config))]

--- a/src/ziggurat/kafka_consumer/consumer_handler.clj
+++ b/src/ziggurat/kafka_consumer/consumer_handler.clj
@@ -12,6 +12,7 @@
 
 (def DEFAULT_POLL_TIMEOUT_MS_CONFIG 1000)
 (def batch-consumption-metric-ns ["ziggurat.batch.consumption" "message.processed"])
+(def commit-metric-ns ["ziggurat.batch.consumption" "offset.commit"])
 
 (defn- publish-batch-process-metrics
   [topic-entity batch-size success-count skip-count retry-count time-taken-in-millis]
@@ -71,6 +72,23 @@
           (log/errorf e "[Consumer Group: %s] Exception received while processing messages \n" topic-entity)
           (retry batch-payload))))))
 
+(defn commit-offsets
+  "Synchronously commits the current consumer offsets. Invoked only when a batch route is
+   configured with `:manual-commit-enabled`, so offsets are committed after a batch has been
+   processed (handler executed and any failures enqueued to the retry queue) rather than by
+   Kafka's background auto-commit.
+
+   A commit failure is logged and reported as a metric but does NOT halt the poll loop; the
+   offsets will be committed on the next successful commit, preserving at-least-once delivery."
+  [^Consumer consumer topic-entity]
+  (let [topic-entity-tag {:topic-entity (name topic-entity)}]
+    (try
+      (.commitSync consumer)
+      (metrics/increment-count commit-metric-ns "success" 1 topic-entity-tag)
+      (catch Exception e
+        (metrics/increment-count commit-metric-ns "failure" 1 topic-entity-tag)
+        (log/errorf e "[Consumer Group: %s] Failed to commit offsets after processing the batch" topic-entity)))))
+
 (defn- create-batch-payload
   [records topic-entity]
   (let [key-value-pairs (map (fn [^ConsumerRecord m]
@@ -80,16 +98,19 @@
 (defn poll-for-messages
   [^Consumer consumer handler-fn topic-entity consumer-config]
   (clog/with-logging-context {:consumer-group topic-entity}
-    (try
-      (loop [records []]
-        (when (not-empty records)
-          (let [batch-payload (create-batch-payload records topic-entity)]
-            (process handler-fn batch-payload)))
-        (recur (seq (.poll consumer (Duration/ofMillis (or (:poll-timeout-ms-config consumer-config) DEFAULT_POLL_TIMEOUT_MS_CONFIG))))))
-      (catch WakeupException e
-        (log/errorf e "WakeupException while polling for messages for: %s" topic-entity))
-      (catch Exception e
-        (log/errorf e "Exception while polling for messages for: %s" topic-entity))
-      (finally (do (log/info "Closing the Kafka Consumer for: " topic-entity)
-                   (.close consumer))))))
+    (let [manual-commit-enabled? (boolean (:manual-commit-enabled consumer-config))]
+      (try
+        (loop [records []]
+          (when (not-empty records)
+            (let [batch-payload (create-batch-payload records topic-entity)]
+              (process handler-fn batch-payload)
+              (when manual-commit-enabled?
+                (commit-offsets consumer topic-entity))))
+          (recur (seq (.poll consumer (Duration/ofMillis (or (:poll-timeout-ms-config consumer-config) DEFAULT_POLL_TIMEOUT_MS_CONFIG))))))
+        (catch WakeupException e
+          (log/errorf e "WakeupException while polling for messages for: %s" topic-entity))
+        (catch Exception e
+          (log/errorf e "Exception while polling for messages for: %s" topic-entity))
+        (finally (do (log/info "Closing the Kafka Consumer for: " topic-entity)
+                     (.close consumer)))))))
 

--- a/test/ziggurat/config_test.clj
+++ b/test/ziggurat/config_test.clj
@@ -210,6 +210,15 @@
             auto-commit-interval-ms (.getProperty props "auto.commit.interval.ms")]
         (is (= auto-commit-interval-ms "5000"))))
 
+    (testing "converts enable-auto-commit to enable.auto.commit and does not leak the manual-commit-enabled flag"
+      (let [config-map              {:enable-auto-commit    false
+                                     :manual-commit-enabled true}
+            props                   (build-consumer-config-properties config-map)
+            enable-auto-commit      (.getProperty props "enable.auto.commit")
+            manual-commit-enabled   (.getProperty props "manual.commit.enabled" "NOT FOUND")]
+        (is (= enable-auto-commit "false"))
+        (is (= manual-commit-enabled "NOT FOUND"))))
+
     (testing "valid kafka streams configs does not convert commit-interval-ms to auto-commit-interval-ms"
       (let [config-map              {:commit-interval-ms 5000}
             props                   (build-streams-config-properties config-map)

--- a/test/ziggurat/kafka_consumer/consumer_handler_test.clj
+++ b/test/ziggurat/kafka_consumer/consumer_handler_test.clj
@@ -70,7 +70,55 @@
                                    (is (= (:value (first (:batch message))) "world"))
                                    (is (= (:topic-entity message) :random-consumer-id))
                                    (is (= (:retry-count message) nil))))]
-        (ch/poll-for-messages kafka-consumer nil :random-consumer-id {:consumer-group-id "some-id" :poll-timeout-ms-config 1000})))))
+        (ch/poll-for-messages kafka-consumer nil :random-consumer-id {:consumer-group-id "some-id" :poll-timeout-ms-config 1000}))))
+  (testing "commits offsets after a batch is processed when manual-commit-enabled is true"
+    (let [commit-count (atom 0)
+          is-polled    (atom 0)
+          kafka-consumer (reify Consumer
+                           (^ConsumerRecords poll [_ ^Duration _]
+                             (if (< @is-polled 1)
+                               (do (swap! is-polled inc) dummy-consumer-records)
+                               (throw (WakeupException.))))
+                           (close [_]))]
+      (with-redefs [ch/process        (fn [_ _] nil)
+                    ch/commit-offsets (fn [_ _] (swap! commit-count inc))]
+        (ch/poll-for-messages kafka-consumer nil :random-consumer-id {:consumer-group-id "some-id" :poll-timeout-ms-config 1000 :manual-commit-enabled true})
+        (is (= 1 @commit-count)))))
+  (testing "does not commit offsets when manual-commit-enabled is not set (auto-commit behaviour is preserved)"
+    (let [commit-count (atom 0)
+          is-polled    (atom 0)
+          kafka-consumer (reify Consumer
+                           (^ConsumerRecords poll [_ ^Duration _]
+                             (if (< @is-polled 1)
+                               (do (swap! is-polled inc) dummy-consumer-records)
+                               (throw (WakeupException.))))
+                           (close [_]))]
+      (with-redefs [ch/process        (fn [_ _] nil)
+                    ch/commit-offsets (fn [_ _] (swap! commit-count inc))]
+        (ch/poll-for-messages kafka-consumer nil :random-consumer-id {:consumer-group-id "some-id" :poll-timeout-ms-config 1000})
+        (is (= 0 @commit-count))))))
+
+(deftest commit-offsets-test
+  (testing "commits the consumer offsets synchronously and reports a success metric"
+    (let [committed (atom false)
+          metric    (atom nil)
+          kafka-consumer (reify Consumer
+                           (commitSync [_] (reset! committed true))
+                           (close [_]))]
+      (with-redefs [metrics/increment-count (fn [metric-ns metric-name _ _] (reset! metric [metric-ns metric-name]))]
+        (ch/commit-offsets kafka-consumer :consumer-1)
+        (is (true? @committed))
+        (is (= ch/commit-metric-ns (first @metric)))
+        (is (= "success" (second @metric))))))
+  (testing "does not throw and reports a failure metric when commitSync fails (loop keeps running)"
+    (let [metric (atom nil)
+          kafka-consumer (reify Consumer
+                           (commitSync [_] (throw (Exception. "commit failed")))
+                           (close [_]))]
+      (with-redefs [metrics/increment-count (fn [metric-ns metric-name _ _] (reset! metric [metric-ns metric-name]))]
+        (is (nil? (ch/commit-offsets kafka-consumer :consumer-1)))
+        (is (= ch/commit-metric-ns (first @metric)))
+        (is (= "failure" (second @metric)))))))
 
 (deftest process-function-test
   (testing "should publish metrics for batch size, success count, failure count, retry-count and execution time after processing is finished"

--- a/test/ziggurat/kafka_consumer/consumer_test.clj
+++ b/test/ziggurat/kafka_consumer/consumer_test.clj
@@ -18,3 +18,11 @@
   (testing "returns nil when invalid configs are provided (KafkaConsumer throws Exception)"
     (let [consumer-config (get-in (ziggurat-config) [:batch-routes :consumer-1])]
       (is (= nil (create-consumer :consumer-1 (assoc-in consumer-config [:consumer-group-id] nil)))))))
+
+(deftest with-manual-commit-config-test
+  (let [with-manual-commit-config #'ziggurat.kafka-consumer.consumer/with-manual-commit-config]
+    (testing "disables kafka auto-commit when manual-commit-enabled is true"
+      (is (false? (:enable-auto-commit (with-manual-commit-config {:manual-commit-enabled true})))))
+    (testing "leaves auto-commit untouched when manual-commit-enabled is absent or false"
+      (is (nil? (:enable-auto-commit (with-manual-commit-config {}))))
+      (is (nil? (:enable-auto-commit (with-manual-commit-config {:manual-commit-enabled false})))))))


### PR DESCRIPTION
## Problem

Batch consumers commit Kafka offsets via background auto-commit (`enable.auto.commit=true`), which commits on a timer independently of batch processing. If a consumer dies after an offset is auto-committed but before the batch is processed (and its failures enqueued for retry), those messages are lost. This has caused message loss in production.

## Solution

Add an opt-in per-batch-route flag `:manual-commit-enabled` (default `false`). When enabled, auto-commit is turned off and offsets are committed with `commitSync` only **after** a batch is processed — guaranteeing at-least-once
delivery. Commit failures are logged + metered (`ziggurat.batch.consumption.offset.commit`) but don't halt the loop.
Default `false` keeps existing behaviour unchanged — fully backward compatible.